### PR TITLE
Allow renderpass as an overlay where caller is responsible for cleari…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ The aim of this is to allow a simple enough API to separate UI nicely out of you
 # Usage
 1. Create your own renderer with Vulkano, and allow access to Vulkano's gfx queue `Arc<Queue>` and Vulkano's winit surface `Arc<Surface<Window>>`
 2. Create Gui integration with the surface & gfx queue
+
 ```rust
-// Has its own renderpass
-let mut gui = Gui::new(renderer.surface(), renderer.queue());
+// Has its own renderpass (is_overlay = false means that the renderpass will clear the image, true means
+// that the caller is responsible for clearing the image
+let mut gui = Gui::new(renderer.surface(), renderer.queue(), false);
 // Or with subpass
 let mut gui = Gui::new_with_subpass(renderer.surface(), renderer.queue(), subpass);
 ```
+
 3. Inside your event loop, update `gui` integration
+
 ```rust
 event_loop.run(move |event, _, control_flow| {
     // Update Egui integration so the UI works!
@@ -26,6 +30,7 @@ event_loop.run(move |event, _, control_flow| {
     // ...match event {..}
 });
 ```
+
 4. Fill immediate mode UI through the integration in `Event::RedrawRequested` before you render
 ```rust
 gui.immediate_ui(|gui| {
@@ -41,8 +46,7 @@ renderer.render(&mut gui); //... and inside render function:
 // future = acquired future from previous_frame_end.join(swapchain_acquire_future) and
 // image_view_to_draw_on = the final image onto which you wish to render UI, usually e.g.
 // self.final_images[image_num].clone() = one of your swap chain images.
-// [0.0, 0.0, 0.0, 0.0] = clear color
-let after_future = gui.draw_on_image(future, image_view_to_draw_on, [0.0, 0.0, 0.0, 0.0]);
+let after_future = gui.draw_on_image(future, image_view_to_draw_on);
 
 // Or if you created the integration with subpass
 let cb = gui.draw_on_subpass_image(framebuffer_dimensions);

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use egui::{ScrollArea, TextEdit, TextStyle};
 use egui_winit_vulkano::Gui;
 use vulkano::{
-    device::{Device, DeviceExtensions, Features, Queue, physical::PhysicalDevice},
+    device::{physical::PhysicalDevice, Device, DeviceExtensions, Features, Queue},
     image::{view::ImageView, ImageUsage, SwapchainImage},
     instance::{Instance, InstanceExtensions},
     swapchain,
@@ -39,7 +39,7 @@ pub fn main() {
     let mut renderer =
         SimpleGuiRenderer::new(&event_loop, window_size, PresentMode::Immediate, "Minimal");
     // After creating the renderer (window, gfx_queue) create out gui integration
-    let mut gui = Gui::new(renderer.surface(), renderer.queue());
+    let mut gui = Gui::new(renderer.surface(), renderer.queue(), false);
     // Create gui state (pass anything your state requires)
     let mut code = CODE.to_owned();
     event_loop.run(move |event, _, control_flow| {
@@ -261,8 +261,7 @@ impl SimpleGuiRenderer {
         }
         // Render GUI
         let future = self.previous_frame_end.take().unwrap().join(acquire_future);
-        let after_future =
-            gui.draw_on_image(future, self.final_images[image_num].clone(), [0.0, 0.0, 0.0, 0.0]);
+        let after_future = gui.draw_on_image(future, self.final_images[image_num].clone());
         // Finish render
         self.finish(after_future, image_num);
     }

--- a/examples/subpass.rs
+++ b/examples/subpass.rs
@@ -14,7 +14,7 @@ use egui_winit_vulkano::Gui;
 use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer},
     command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SubpassContents},
-    device::{Device, DeviceExtensions, Features, Queue, physical::PhysicalDevice},
+    device::{physical::PhysicalDevice, Device, DeviceExtensions, Features, Queue},
     format::Format,
     image::{view::ImageView, ImageUsage, SwapchainImage},
     instance::{Instance, InstanceExtensions},
@@ -385,13 +385,7 @@ impl SimpleGuiRenderer {
         )
         .unwrap();
         secondary_builder
-            .draw(
-                self.pipeline.clone(),
-                &dynamic_state,
-                vec![self.vertex_buffer.clone()],
-                (),
-                (),
-            )
+            .draw(self.pipeline.clone(), &dynamic_state, vec![self.vertex_buffer.clone()], (), ())
             .unwrap();
         let cb = secondary_builder.build().unwrap();
         builder.execute_commands(cb).unwrap();

--- a/examples/wholesome/frame_system.rs
+++ b/examples/wholesome/frame_system.rs
@@ -116,11 +116,10 @@ impl FrameSystem {
         )
         .unwrap();
         command_buffer_builder
-            .begin_render_pass(
-                framebuffer.clone(),
-                SubpassContents::SecondaryCommandBuffers,
-                vec![[0.0, 0.0, 0.0, 0.0].into(), 1.0f32.into()],
-            )
+            .begin_render_pass(framebuffer.clone(), SubpassContents::SecondaryCommandBuffers, vec![
+                [0.0, 0.0, 0.0, 0.0].into(),
+                1.0f32.into(),
+            ])
             .unwrap();
 
         Frame {

--- a/examples/wholesome/main.rs
+++ b/examples/wholesome/main.rs
@@ -135,7 +135,7 @@ pub fn main() {
     );
     // After creating the renderer (window, gfx_queue) create out gui integration
     // It requires access to surface (Window, devices etc.) and Vulkano's gfx queue
-    let mut gui = Gui::new(renderer.surface(), renderer.queue());
+    let mut gui = Gui::new(renderer.surface(), renderer.queue(), false);
     // Renderer created AttachmentImages for our scene, let's access them
     let scene_images = renderer.scene_images();
     // Create gui state (pass anything your state requires)

--- a/examples/wholesome/renderer.rs
+++ b/examples/wholesome/renderer.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use cgmath::{Matrix4, SquareMatrix};
 use egui_winit_vulkano::Gui;
 use vulkano::{
-    device::{Device, DeviceExtensions, Features, Queue, physical::PhysicalDevice},
+    device::{physical::PhysicalDevice, Device, DeviceExtensions, Features, Queue},
     image::{view::ImageView, AttachmentImage, ImageUsage, ImageViewAbstract, SwapchainImage},
     instance::{Instance, InstanceExtensions},
     swapchain,
@@ -251,8 +251,7 @@ impl Renderer {
         self.render_scene();
         // Finally render GUI on our swapchain color image attachments
         let future = self.previous_frame_end.take().unwrap().join(acquire_future);
-        let after_future =
-            gui.draw_on_image(future, self.final_images[image_num].clone(), [0.0, 0.0, 0.0, 0.0]);
+        let after_future = gui.draw_on_image(future, self.final_images[image_num].clone());
         // Finish render
         self.finish(after_future, image_num);
     }


### PR DESCRIPTION
Adds an option where the render pass does not clear the input image. This is useful if you wish to handle the clearing in your own render passes.