### PR TITLE
Fix blinking resize cursor, incorrect buffer resizing, subpass GpuLocked and bump egui to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/hakolao/egui_winit_vulkano"
 
 [dependencies]
 copypasta = "0.7.1"
-egui = "0.15.0"
+egui = "0.16"
 image = "0.23.14"
 vulkano = "0.27.1"
 vulkano-win = "0.27.1"
@@ -20,4 +20,4 @@ winit = "0.25.0"
 
 [dev-dependencies]
 cgmath = "0.18.0"
-egui_demo_lib = "0.15.0"
+egui_demo_lib = "0.16"

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,7 +10,7 @@
 use std::time::Instant;
 
 use copypasta::{ClipboardContext, ClipboardProvider};
-use egui::{paint::ClippedMesh, CtxRef, Pos2, RawInput, Rect, Vec2};
+use egui::{epaint::ClippedMesh, CtxRef, Pos2, RawInput, Rect, Vec2};
 use winit::{
     dpi::PhysicalSize,
     event::{ElementState, Event, ModifiersState, MouseScrollDelta, VirtualKeyCode, WindowEvent},

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use egui::{paint::Mesh, Rect};
+use egui::{epaint::Mesh, Rect};
 use vulkano::{
     buffer::{BufferAccess, BufferUsage, CpuAccessibleBuffer},
     command_buffer::{


### PR DESCRIPTION
Really awesome lib! Worked like a charm except a few minor issues that were relatively easy to fix.

I didn't understand why to skip a frame after resizing buffers. I removed that.

Also, maybe I'm misunderstanding how to use the lib with subpass but for me I kept getting GpuLocked sometimes and determined that I needed to previous_frame_end.wait(None) which blocks the thread to avoid it. I settled for reallocating the buffers instead in the case when a write lock can't be obtained. For me, it happens on about 10% of frames. I don't really know how bad of an impact this would have. Perhaps you could come up with a better solution?

On windows 10, the resize cursor for the window kept blinking, which was due to updating the cursor when it's outside the window. I fixed that minor annoyance too.

I don't have much experience with Vulkan at all. I tried to split up the changes in 3 different separate commits.

BR Karl