### PR TITLE
Fix issue #16: font component ordering problem

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -283,7 +283,7 @@ impl Renderer {
                 height: delta.image.height() as u32,
                 array_layers: 1,
             },
-            Format::R8G8B8A8_SRGB,
+            Format::R8G8B8A8_UNORM,
             vulkano::image::MipmapsCount::One,
             ImageUsage {
                 transfer_dst: true,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -283,7 +283,7 @@ impl Renderer {
                 height: delta.image.height() as u32,
                 array_layers: 1,
             },
-            self.format,
+            Format::R8G8B8A8_SRGB,
             vulkano::image::MipmapsCount::One,
             ImageUsage {
                 transfer_dst: true,


### PR DESCRIPTION
I was wrong when I suspected sRGB to be the problem with my setup: the real cause was incorrect ordering of pixel components when creating font texture images.

The font seems to use BGRA ordering, my RX 5700 setup uses RGBA ordering, whereas Ryzen 4700U uses BGRA, which is why the problem wasn't present there.

By changing the ordering to be BGRA when creating font image I managed to resolve the color artifacting issue on my setup. I'm not sure if that ordering is fixed for egui font images, but that worked fine for different fonts I tested it with so far.

As a side note: the sRGB/RGB issue is still present when trying different output formats, but it's not as critical for my use case. I will try fixing that as well, however.