### PR TITLE
Allow sRGB and non-sRGB target surfaces to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ The aim of this is to allow a simple enough API to separate UI nicely out of you
 ```rust
 // Has its own renderpass (is_overlay = false means that the renderpass will clear the image, true means
 // that the caller is responsible for clearing the image
-let mut gui = Gui::new(renderer.surface(), renderer.queue(), false);
+let mut gui = Gui::new(renderer.surface(), None, renderer.queue(), false);
 // Or with subpass. This means that you must create the renderpass yourself. Egui subpass will then draw on your
 // image.
-let mut gui = Gui::new_with_subpass(renderer.surface(), renderer.queue(), subpass);
+let mut gui = Gui::new_with_subpass(renderer.surface(), None, renderer.queue(), subpass);
 ```
 
 3. Inside your event loop, update `gui` integration with `WindowEvent`

--- a/examples/demo_app.rs
+++ b/examples/demo_app.rs
@@ -30,7 +30,12 @@ pub fn main() {
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let mut gui = {
         let renderer = windows.get_primary_renderer_mut().unwrap();
-        Gui::new(renderer.surface(), renderer.graphics_queue(), false)
+        Gui::new(
+            renderer.surface(),
+            Some(vulkano::format::Format::B8G8R8A8_SRGB),
+            renderer.graphics_queue(),
+            false,
+        )
     };
     // Display the demo application that ships with egui.
     let mut demo_app = egui_demo_lib::DemoWindows::default();

--- a/examples/demo_app.rs
+++ b/examples/demo_app.rs
@@ -40,7 +40,7 @@ pub fn main() {
         let renderer = windows.get_renderer_mut(window1).unwrap();
         Gui::new(
             renderer.surface(),
-            Some(vulkano::format::Format::B8G8R8A8_SRGB),
+            Some(renderer.swapchain_format()),
             renderer.graphics_queue(),
             false,
         )
@@ -49,7 +49,7 @@ pub fn main() {
         let renderer = windows.get_renderer_mut(window2).unwrap();
         Gui::new(
             renderer.surface(),
-            Some(vulkano::format::Format::B8G8R8A8_UNORM),
+            Some(renderer.swapchain_format()),
             renderer.graphics_queue(),
             false,
         )

--- a/examples/demo_app.rs
+++ b/examples/demo_app.rs
@@ -17,6 +17,9 @@ use winit::{
     event_loop::{ControlFlow, EventLoop},
 };
 
+// Simply create egui demo apps to test everything works correctly.
+// Creates two windows with different color formats for their swapchain.
+
 pub fn main() {
     // Winit event loop
     let event_loop = EventLoop::new();

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -35,7 +35,12 @@ pub fn main() {
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let mut gui = {
         let renderer = windows.get_primary_renderer_mut().unwrap();
-        Gui::new(renderer.surface(), renderer.graphics_queue(), false)
+        Gui::new(
+            renderer.surface(),
+            Some(vulkano::format::Format::B8G8R8A8_SRGB),
+            renderer.graphics_queue(),
+            false,
+        )
     };
     // Create gui state (pass anything your state requires)
     let mut code = CODE.to_owned();
@@ -108,6 +113,6 @@ pub fn main() {
 const CODE: &str = r#"
 # Some markup
 ```
-let mut gui = Gui::new(renderer.surface(), renderer.queue());
+let mut gui = Gui::new(renderer.surface(), None, renderer.queue());
 ```
 "#;

--- a/examples/subpass.rs
+++ b/examples/subpass.rs
@@ -65,6 +65,7 @@ pub fn main() {
     // Create gui subpass
     let mut gui = Gui::new_with_subpass(
         windows.get_primary_renderer_mut().unwrap().surface(),
+        Some(vulkano::format::Format::B8G8R8A8_SRGB),
         windows.get_primary_renderer_mut().unwrap().graphics_queue(),
         gui_pipeline.gui_pass(),
     );

--- a/examples/wholesome/main.rs
+++ b/examples/wholesome/main.rs
@@ -45,9 +45,9 @@ impl GuiState {
     pub fn new(gui: &mut Gui, scene_image: DeviceImageView, scene_view_size: [u32; 2]) -> GuiState {
         // tree.png asset is from https://github.com/sotrh/learn-wgpu/tree/master/docs/beginner/tutorial5-textures
         let image_texture_id1 =
-            gui.register_user_image(include_bytes!("./assets/tree.png"), Format::R8G8B8A8_SRGB);
+            gui.register_user_image(include_bytes!("./assets/tree.png"), Format::R8G8B8A8_UNORM);
         let image_texture_id2 =
-            gui.register_user_image(include_bytes!("./assets/doge2.png"), Format::R8G8B8A8_SRGB);
+            gui.register_user_image(include_bytes!("./assets/doge2.png"), Format::R8G8B8A8_UNORM);
 
         GuiState {
             show_texture_window1: true,
@@ -119,13 +119,11 @@ pub fn main() {
     let context = VulkanoContext::new(VulkanoConfig::default());
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
-    windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB)
-    });
+    windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |_| {});
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let mut gui = {
         let renderer = windows.get_primary_renderer_mut().unwrap();
-        Gui::new(renderer.surface(), renderer.graphics_queue(), false)
+        Gui::new(renderer.surface(), None, renderer.graphics_queue(), false)
     };
     // Create a simple image to which we'll draw the triangle scene
     let scene_image = StorageImage::general_purpose_image_view(

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 
 use egui::{ClippedPrimitive, TexturesDelta};
 use vulkano::{
-    command_buffer::SecondaryAutoCommandBuffer, device::Queue, image::ImageViewAbstract,
-    render_pass::Subpass, swapchain::Surface, sync::GpuFuture,
+    command_buffer::SecondaryAutoCommandBuffer, device::Queue, format::Format,
+    image::ImageViewAbstract, render_pass::Subpass, swapchain::Surface, sync::GpuFuture,
 };
 use winit::window::Window;
 
@@ -36,22 +36,25 @@ impl Gui {
     /// and gfx queue. Created with this, the renderer will own a render pass which is useful to e.g. place your render pass' images
     /// onto egui windows
     /// - `surface`: Vulkano's Winit Surface [`Arc<Surface<Window>>`]
+    /// - `preferred_format`: If target surface was created with custom format, it has to be
+    /// provided here. If the surface uses default format, use None
     /// - `gfx_queue`: Vulkano's [`Queue`]
     /// - `is_overlay`: If true, you should be responsible for clearing the image before `draw_on_image`, else it gets cleared
-    ///
-    /// Note that your swapchain images should be created with `vulkano::format::Format::B8G8R8A8_SRGB`
-    pub fn new(surface: Arc<Surface<Window>>, gfx_queue: Arc<Queue>, is_overlay: bool) -> Gui {
-        let format = vulkano::format::Format::B8G8R8A8_SRGB;
-        let formats = gfx_queue
-            .device()
-            .physical_device()
-            .surface_formats(&surface, Default::default())
-            .unwrap();
-        assert!(
-            formats.iter().find(|f| f.0 == format).is_some(),
-            "Swapchain format does not support {:?}",
-            format
-        );
+    pub fn new(
+        surface: Arc<Surface<Window>>,
+        preferred_format: Option<Format>,
+        gfx_queue: Arc<Queue>,
+        is_overlay: bool,
+    ) -> Gui {
+        // Pick preferred format if provided, otherwise use the default one
+        let format = preferred_format.unwrap_or_else(|| {
+            gfx_queue
+                .device()
+                .physical_device()
+                .surface_formats(&surface, Default::default())
+                .unwrap()[0]
+                .0
+        });
         let max_texture_side =
             gfx_queue.device().physical_device().properties().max_image_array_layers as usize;
         let renderer = Renderer::new_with_render_pass(gfx_queue, format, is_overlay);
@@ -66,24 +69,21 @@ impl Gui {
     }
 
     /// Same as `new` but instead of integration owning a render pass, egui renders on your subpass
-    ///
-    /// Note that your swapchain images should be created with `vulkano::format::Format::B8G8R8A8_SRGB`
     pub fn new_with_subpass(
         surface: Arc<Surface<Window>>,
+        preferred_format: Option<Format>,
         gfx_queue: Arc<Queue>,
         subpass: Subpass,
     ) -> Gui {
-        let format = vulkano::format::Format::B8G8R8A8_SRGB;
-        let formats = gfx_queue
-            .device()
-            .physical_device()
-            .surface_formats(&surface, Default::default())
-            .unwrap();
-        assert!(
-            formats.iter().find(|f| f.0 == format).is_some(),
-            "Swapchain format does not support {:?}",
-            format
-        );
+        // Pick preferred format if provided, otherwise use the default one
+        let format = preferred_format.unwrap_or_else(|| {
+            gfx_queue
+                .device()
+                .physical_device()
+                .surface_formats(&surface, Default::default())
+                .unwrap()[0]
+                .0
+        });
         let max_texture_side =
             gfx_queue.device().physical_device().properties().max_image_array_layers as usize;
         let renderer = Renderer::new_with_subpass(gfx_queue, format, subpass);
@@ -140,15 +140,6 @@ impl Gui {
                 "Gui integration has been created with subpass, use `draw_on_subpass_image` \
                  instead"
             )
-        }
-
-        let format = final_image.format();
-        if format != Some(vulkano::format::Format::B8G8R8A8_SRGB) {
-            panic!(
-                "Render target image color format is wrong {:?}, should be {:?}",
-                format,
-                Some(vulkano::format::Format::B8G8R8A8_SRGB)
-            );
         }
 
         let (clipped_meshes, textures_delta) = self.extract_draw_data_at_frame_end();


### PR DESCRIPTION
I managed to get both sRGB and non-sRGB output formats working consistently. I also added (breaking change) an option to provide the specific format the surface was created with, if it's not default, otherwise format check would panic.