### PR TITLE
Updated to Vulkano v0.32.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_winit_vulkano"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["hakolao <okkohakola@gmail.com>"]
 edition = "2018"
 description = "Egui immediate mode gui integration with winit and Vulkano"
@@ -17,16 +17,16 @@ links = ["egui-winit/links"]
 clipboard = ["egui-winit/clipboard"]
 
 [dependencies]
-ahash = "0.7.6"
-bytemuck = "1.8.0"
+ahash = "0.8.1"
+bytemuck = "1.12.2"
 egui = "0.19.0"
 egui-winit = "0.19.0"
-image = "0.23.14"
-winit = "0.27"
-vulkano = "0.31.0"
-vulkano-shaders = "0.31.0"
+image = "0.24.4"
+winit = "0.27.5"
+vulkano = "0.32.0"
+vulkano-shaders = "0.32.0"
 
 [dev-dependencies]
 cgmath = "0.18.0"
 egui_demo_lib = "0.19.0"
-vulkano-util = "0.31.0"
+vulkano-util = "0.32.0"

--- a/examples/demo_app.rs
+++ b/examples/demo_app.rs
@@ -110,7 +110,7 @@ pub fn main() {
                     renderer.present(after_future, true);
                 }
                 Event::MainEventsCleared => {
-                    renderer.surface().window().request_redraw();
+                    renderer.window().request_redraw();
                 }
                 _ => (),
             }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -48,9 +48,7 @@ pub fn main() {
     event_loop.run(move |event, _, control_flow| {
         let renderer = windows.get_primary_renderer_mut().unwrap();
         match event {
-            Event::WindowEvent { event, window_id }
-                if window_id == renderer.surface().window().id() =>
-            {
+            Event::WindowEvent { event, window_id } if window_id == renderer.window().id() => {
                 // Update Egui integration so the UI works!
                 let _pass_events_to_game = !gui.update(&event);
                 match event {
@@ -104,7 +102,7 @@ pub fn main() {
                 renderer.present(after_future, true);
             }
             Event::MainEventsCleared => {
-                renderer.surface().window().request_redraw();
+                renderer.window().request_redraw();
             }
             _ => (),
         }

--- a/examples/wholesome/renderer.rs
+++ b/examples/wholesome/renderer.rs
@@ -10,7 +10,10 @@
 use std::sync::Arc;
 
 use cgmath::{Matrix4, SquareMatrix};
-use vulkano::{device::Queue, image::ImageViewAbstract, sync::GpuFuture};
+use vulkano::{
+    command_buffer::allocator::StandardCommandBufferAllocator, device::Queue,
+    image::ImageViewAbstract, memory::allocator::StandardMemoryAllocator, sync::GpuFuture,
+};
 use vulkano_util::renderer::DeviceImageView;
 
 use crate::{
@@ -23,10 +26,21 @@ pub struct RenderPipeline {
     draw_pipeline: TriangleDrawSystem,
 }
 
+#[derive(Clone)]
+pub struct Allocators {
+    pub command_buffers: Arc<StandardCommandBufferAllocator>,
+    pub memory: Arc<StandardMemoryAllocator>,
+}
+
 impl RenderPipeline {
-    pub fn new(queue: Arc<Queue>, image_format: vulkano::format::Format) -> Self {
-        let frame_system = FrameSystem::new(queue.clone(), image_format);
-        let draw_pipeline = TriangleDrawSystem::new(queue.clone(), frame_system.deferred_subpass());
+    pub fn new(
+        queue: Arc<Queue>,
+        image_format: vulkano::format::Format,
+        allocators: &Allocators,
+    ) -> Self {
+        let frame_system = FrameSystem::new(queue.clone(), image_format, allocators.clone());
+        let draw_pipeline =
+            TriangleDrawSystem::new(queue.clone(), frame_system.deferred_subpass(), allocators);
 
         Self { frame_system, draw_pipeline }
     }


### PR DESCRIPTION
I updated the source and examples to use the latest Cargo crate versions and updated this crate's version by one minor (`0.20.1`). The majority of changes relate to explicitly specifying the VRAM allocators being used and the `Surface` no longer stores an *explicit* reference to the winit `Window` and needs to be typecast.

There are a couple of changes made that are unrelated to the above due to my use of the `cargo fmt` command which re-formatted a handful of lines, but it makes no functional difference. I also removed a couple of unnecessary `&` references as hinted by `clippy`.

Cheers!