### PR TITLE
texture filter support

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -631,7 +631,6 @@ impl Renderer {
             need_srgb_conv: self.need_srgb_conv.into(),
         };
 
-        println!("{}", clipped_meshes.len());
         for ClippedPrimitive { clip_rect, primitive } in clipped_meshes {
             match primitive {
                 Primitive::Mesh(mesh) => {


### PR DESCRIPTION
currently magnification- and minification- TextureFilters get ignored by the vulkano integration

TextureOptions {
    magnification: TextureFilter::Nearest,
    minification: TextureFilter::Nearest,
},

This PR enables the renderer to assign the correct sampler to a TextureId 