### PR TITLE
Fixes fullscreen crash on AMD GPUs

### DIFF
--- a/examples/demo_app.rs
+++ b/examples/demo_app.rs
@@ -29,11 +29,13 @@ pub fn main() {
     let mut windows = VulkanoWindows::default();
     let window1 =
         windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-            ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB)
+            ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
+            ci.min_image_count = ci.min_image_count.max(2);
         });
     let window2 =
         windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-            ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM)
+            ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
+            ci.min_image_count = ci.min_image_count.max(2);
         });
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let mut gui1 = {

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -32,7 +32,8 @@ pub fn main() {
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
     windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB)
+        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
+        ci.min_image_count = ci.min_image_count.max(2);
     });
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let mut gui = {

--- a/examples/multisample.rs
+++ b/examples/multisample.rs
@@ -60,6 +60,7 @@ pub fn main() {
     windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
         ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
         ci.image_usage = ImageUsage::TRANSFER_DST | ci.image_usage;
+        ci.min_image_count = ci.min_image_count.max(2);
     });
     // Create out gui pipeline
     let mut pipeline = MSAAPipeline::new(

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -42,7 +42,10 @@ pub fn main() {
         &event_loop,
         &context,
         &WindowDescriptor { width: 400.0, height: 400.0, ..Default::default() },
-        |ci| ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB),
+        |ci| {
+            ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
+            ci.min_image_count = ci.min_image_count.max(2);
+        },
     );
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let (mut gui, scene) = {

--- a/examples/subpass.rs
+++ b/examples/subpass.rs
@@ -57,7 +57,8 @@ pub fn main() {
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
     windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB)
+        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
+        ci.min_image_count = ci.min_image_count.max(2);
     });
     // Create out gui pipeline
     let mut gui_pipeline = SimpleGuiPipeline::new(

--- a/examples/wholesome/main.rs
+++ b/examples/wholesome/main.rs
@@ -125,7 +125,8 @@ pub fn main() {
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
     windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB)
+        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
+        ci.min_image_count = ci.min_image_count.max(2);
     });
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let mut gui = {


### PR DESCRIPTION
There's a bug in AMD drivers that causes the examples in this project to crash in fullscreen. Normally, they run fine in windowed mode but as soon as you add this line of code, they crash:

```rs
windows.get_primary_window().unwrap().set_fullscreen(Some(winit::window::Fullscreen::Borderless(None)));
```

See more here: https://github.com/vulkano-rs/vulkano/pull/2218