### PR TITLE
Fixed srgb

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The aim of this is to allow a simple enough API to separate UI nicely out of you
 
 ```rust
 // Has its own renderpass. Modify GuiConfig to determine image clear behavior etc.
-let mut gui = Gui::new(&event_loop, renderer.surface(), renderer.queue(), GuiConfig::default());
+let mut gui = Gui::new(&event_loop, renderer.surface(), renderer.queue(), renderer.swapchain_format(), GuiConfig::default());
 // Or with subpass. This means that you must create the renderpass yourself. Egui subpass will then draw on your
 // image.
-let mut gui = Gui::new_with_subpass(&event_loop, renderer.surface(), renderer.queue(), subpass, GuiConfig::default());
+let mut gui = Gui::new_with_subpass(&event_loop, renderer.surface(), renderer.queue(), renderer.swapchain_format(), subpass, GuiConfig::default());
 ```
 
 3. Inside your event loop, update `gui` integration with `WindowEvent`
@@ -56,6 +56,8 @@ renderer.present(after_future, true);
 let cb = gui.draw_on_subpass_image(framebuffer_dimensions);
 draw_pass.execute(cb);
 ```
+Note that Egui prefers UNORM render targets. Using an output format with sRGB requires `GuiConfig::allow_srgb_render_target` to be set, to acknowledge that using sRGB will cause minor discoloration of UI elements due to blending in linear color space and not sRGB as Egui expects.
+
 See the examples directory for better usage guidance.
 
 Remember, on Linux, you need to install following to run Egui

--- a/examples/demo_app.rs
+++ b/examples/demo_app.rs
@@ -46,17 +46,14 @@ pub fn main() {
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let mut gui1 = {
         let renderer = windows.get_renderer_mut(window1).unwrap();
-        Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), GuiConfig {
-            preferred_format: Some(renderer.swapchain_format()),
-            ..Default::default()
+        Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), renderer.swapchain_format(), GuiConfig {
+            allow_srgb_render_target: true,
+            ..GuiConfig::default()
         })
     };
     let mut gui2 = {
         let renderer = windows.get_renderer_mut(window2).unwrap();
-        Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), GuiConfig {
-            preferred_format: Some(renderer.swapchain_format()),
-            ..Default::default()
-        })
+        Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), renderer.swapchain_format(), GuiConfig::default())
     };
     // Display the demo application that ships with egui.
     let mut demo_app1 = egui_demo_lib::DemoWindows::default();

--- a/examples/demo_app.rs
+++ b/examples/demo_app.rs
@@ -27,33 +27,50 @@ pub fn main() {
     let context = VulkanoContext::new(VulkanoConfig::default());
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
-    let window1 =
-        windows.create_window(&event_loop, &context, &WindowDescriptor {
+    let window1 = windows.create_window(
+        &event_loop,
+        &context,
+        &WindowDescriptor {
             title: String::from("egui_winit_vulkano SRGB"),
             ..WindowDescriptor::default()
-        }, |ci| {
+        },
+        |ci| {
             ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
             ci.min_image_count = ci.min_image_count.max(2);
-        });
-    let window2 =
-        windows.create_window(&event_loop, &context, &WindowDescriptor {
+        },
+    );
+    let window2 = windows.create_window(
+        &event_loop,
+        &context,
+        &WindowDescriptor {
             title: String::from("egui_winit_vulkano UNORM"),
             ..WindowDescriptor::default()
-        }, |ci| {
+        },
+        |ci| {
             ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
             ci.min_image_count = ci.min_image_count.max(2);
-        });
+        },
+    );
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let mut gui1 = {
         let renderer = windows.get_renderer_mut(window1).unwrap();
-        Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), renderer.swapchain_format(), GuiConfig {
-            allow_srgb_render_target: true,
-            ..GuiConfig::default()
-        })
+        Gui::new(
+            &event_loop,
+            renderer.surface(),
+            renderer.graphics_queue(),
+            renderer.swapchain_format(),
+            GuiConfig { allow_srgb_render_target: true, ..GuiConfig::default() },
+        )
     };
     let mut gui2 = {
         let renderer = windows.get_renderer_mut(window2).unwrap();
-        Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), renderer.swapchain_format(), GuiConfig::default())
+        Gui::new(
+            &event_loop,
+            renderer.surface(),
+            renderer.graphics_queue(),
+            renderer.swapchain_format(),
+            GuiConfig::default(),
+        )
     };
     // Display the demo application that ships with egui.
     let mut demo_app1 = egui_demo_lib::DemoWindows::default();

--- a/examples/demo_app.rs
+++ b/examples/demo_app.rs
@@ -28,12 +28,18 @@ pub fn main() {
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
     let window1 =
-        windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
+        windows.create_window(&event_loop, &context, &WindowDescriptor {
+            title: String::from("egui_winit_vulkano SRGB"),
+            ..WindowDescriptor::default()
+        }, |ci| {
             ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
             ci.min_image_count = ci.min_image_count.max(2);
         });
     let window2 =
-        windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
+        windows.create_window(&event_loop, &context, &WindowDescriptor {
+            title: String::from("egui_winit_vulkano UNORM"),
+            ..WindowDescriptor::default()
+        }, |ci| {
             ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
             ci.min_image_count = ci.min_image_count.max(2);
         });

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -38,7 +38,13 @@ pub fn main() {
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let mut gui = {
         let renderer = windows.get_primary_renderer_mut().unwrap();
-        Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), renderer.swapchain_format(), GuiConfig::default())
+        Gui::new(
+            &event_loop,
+            renderer.surface(),
+            renderer.graphics_queue(),
+            renderer.swapchain_format(),
+            GuiConfig::default(),
+        )
     };
     // Create gui state (pass anything your state requires)
     let mut code = CODE.to_owned();

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -32,13 +32,13 @@ pub fn main() {
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
     windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
+        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
         ci.min_image_count = ci.min_image_count.max(2);
     });
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let mut gui = {
         let renderer = windows.get_primary_renderer_mut().unwrap();
-        Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), GuiConfig::default())
+        Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), renderer.swapchain_format(), GuiConfig::default())
     };
     // Create gui state (pass anything your state requires)
     let mut code = CODE.to_owned();

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -112,9 +112,9 @@ pub fn main() {
     });
 }
 
-const CODE: &str = r#"
+const CODE: &str = r"
 # Some markup
 ```
 let mut gui = Gui::new(&event_loop, renderer.surface(), None, renderer.queue(), SampleCount::Sample1);
 ```
-"#;
+";

--- a/examples/multisample.rs
+++ b/examples/multisample.rs
@@ -58,7 +58,7 @@ pub fn main() {
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
     windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
+        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
         ci.image_usage = ImageUsage::TRANSFER_DST | ci.image_usage;
         ci.min_image_count = ci.min_image_count.max(2);
     });
@@ -75,8 +75,8 @@ pub fn main() {
         windows.get_primary_renderer_mut().unwrap().surface(),
         windows.get_primary_renderer_mut().unwrap().graphics_queue(),
         pipeline.gui_pass(),
+        windows.get_primary_renderer_mut().unwrap().swapchain_format(),
         GuiConfig {
-            preferred_format: Some(vulkano::format::Format::B8G8R8A8_SRGB),
             // Must match your pipeline's sample count
             samples: SampleCount::Sample4,
             ..Default::default()

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -43,7 +43,7 @@ pub fn main() {
         &context,
         &WindowDescriptor { width: 400.0, height: 400.0, ..Default::default() },
         |ci| {
-            ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
+            ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
             ci.min_image_count = ci.min_image_count.max(2);
         },
     );
@@ -51,10 +51,7 @@ pub fn main() {
     let (mut gui, scene) = {
         let renderer = windows.get_primary_renderer_mut().unwrap();
 
-        let gui = Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), GuiConfig {
-            preferred_format: Some(vulkano::format::Format::B8G8R8A8_SRGB),
-            ..Default::default()
-        });
+        let gui = Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), renderer.swapchain_format(), GuiConfig::default());
 
         let scene = Arc::new(Mutex::new(Scene::new(gui.render_resources())));
 

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -51,7 +51,13 @@ pub fn main() {
     let (mut gui, scene) = {
         let renderer = windows.get_primary_renderer_mut().unwrap();
 
-        let gui = Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), renderer.swapchain_format(), GuiConfig::default());
+        let gui = Gui::new(
+            &event_loop,
+            renderer.surface(),
+            renderer.graphics_queue(),
+            renderer.swapchain_format(),
+            GuiConfig::default(),
+        );
 
         let scene = Arc::new(Mutex::new(Scene::new(gui.render_resources())));
 

--- a/examples/subpass.rs
+++ b/examples/subpass.rs
@@ -57,7 +57,7 @@ pub fn main() {
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
     windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
+        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
         ci.min_image_count = ci.min_image_count.max(2);
     });
     // Create out gui pipeline
@@ -72,10 +72,8 @@ pub fn main() {
         windows.get_primary_renderer_mut().unwrap().surface(),
         windows.get_primary_renderer_mut().unwrap().graphics_queue(),
         gui_pipeline.gui_pass(),
-        GuiConfig {
-            preferred_format: Some(vulkano::format::Format::B8G8R8A8_SRGB),
-            ..Default::default()
-        },
+        windows.get_primary_renderer_mut().unwrap().swapchain_format(),
+        GuiConfig::default(),
     );
 
     // Create gui state (pass anything your state requires)

--- a/examples/wholesome/main.rs
+++ b/examples/wholesome/main.rs
@@ -131,13 +131,13 @@ pub fn main() {
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
     windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
+        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
         ci.min_image_count = ci.min_image_count.max(2);
     });
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let mut gui = {
         let renderer = windows.get_primary_renderer_mut().unwrap();
-        Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), GuiConfig::default())
+        Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), renderer.swapchain_format(), GuiConfig::default())
     };
     // Create a simple image to which we'll draw the triangle scene
     let scene_image = StorageImage::general_purpose_image_view(

--- a/examples/wholesome/main.rs
+++ b/examples/wholesome/main.rs
@@ -137,7 +137,13 @@ pub fn main() {
     // Create gui as main render pass (no overlay means it clears the image each frame)
     let mut gui = {
         let renderer = windows.get_primary_renderer_mut().unwrap();
-        Gui::new(&event_loop, renderer.surface(), renderer.graphics_queue(), renderer.swapchain_format(), GuiConfig::default())
+        Gui::new(
+            &event_loop,
+            renderer.surface(),
+            renderer.graphics_queue(),
+            renderer.swapchain_format(),
+            GuiConfig::default(),
+        )
     };
     // Create a simple image to which we'll draw the triangle scene
     let scene_image = StorageImage::general_purpose_image_view(

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -87,21 +87,9 @@ impl Gui {
     ) -> Gui {
         // Pick preferred format if provided, otherwise use the default one
         let format = get_surface_image_format(&surface, config.preferred_format, &gfx_queue);
-        let max_texture_side =
-            gfx_queue.device().physical_device().properties().max_image_array_layers as usize;
         let renderer =
             Renderer::new_with_render_pass(gfx_queue, format, config.is_overlay, config.samples);
-        let mut egui_winit = egui_winit::State::new(event_loop);
-        egui_winit.set_max_texture_side(max_texture_side);
-        egui_winit.set_pixels_per_point(surface_window(&surface).scale_factor() as f32);
-        Gui {
-            egui_ctx: Default::default(),
-            egui_winit,
-            renderer,
-            surface,
-            shapes: vec![],
-            textures_delta: Default::default(),
-        }
+        Self::new_internal(event_loop, surface, renderer)
     }
 
     /// Same as `new` but instead of integration owning a render pass, egui renders on your subpass
@@ -114,9 +102,18 @@ impl Gui {
     ) -> Gui {
         // Pick preferred format if provided, otherwise use the default one
         let format = get_surface_image_format(&surface, config.preferred_format, &gfx_queue);
-        let max_texture_side =
-            gfx_queue.device().physical_device().properties().max_image_array_layers as usize;
         let renderer = Renderer::new_with_subpass(gfx_queue, format, subpass);
+        Self::new_internal(event_loop, surface, renderer)
+    }
+
+    /// Same as `new` but instead of integration owning a render pass, egui renders on your subpass
+    fn new_internal<T>(
+        event_loop: &EventLoopWindowTarget<T>,
+        surface: Arc<Surface>,
+        renderer: Renderer,
+    ) -> Gui {
+        let max_texture_side =
+            renderer.queue().device().physical_device().properties().max_image_array_layers as usize;
         let mut egui_winit = egui_winit::State::new(event_loop);
         egui_winit.set_max_texture_side(max_texture_side);
         egui_winit.set_pixels_per_point(surface_window(&surface).scale_factor() as f32);

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -43,15 +43,23 @@ pub struct GuiConfig {
 
 impl Default for GuiConfig {
     fn default() -> Self {
-        GuiConfig { allow_srgb_render_target: false, is_overlay: false, samples: SampleCount::Sample1 }
+        GuiConfig {
+            allow_srgb_render_target: false,
+            is_overlay: false,
+            samples: SampleCount::Sample1,
+        }
     }
 }
 
 impl GuiConfig {
     pub fn validate(&self, output_format: Format) {
         if output_format.type_color().unwrap() == NumericType::SRGB {
-            assert!(self.allow_srgb_render_target, "Using an output format with sRGB requires GuiConfig::allow_srgb_render_target to be set! \
-            This ensures the user is aware that rendering to an sRGB render target will breaking blending causing discoloration of UI elements");
+            assert!(
+                self.allow_srgb_render_target,
+                "Using an output format with sRGB requires GuiConfig::allow_srgb_render_target to \
+                 be set! This ensures the user is aware that rendering to an sRGB render target \
+                 will breaking blending causing discoloration of UI elements"
+            );
         }
     }
 }
@@ -79,8 +87,12 @@ impl Gui {
         config: GuiConfig,
     ) -> Gui {
         config.validate(output_format);
-        let renderer =
-            Renderer::new_with_render_pass(gfx_queue, output_format, config.is_overlay, config.samples);
+        let renderer = Renderer::new_with_render_pass(
+            gfx_queue,
+            output_format,
+            config.is_overlay,
+            config.samples,
+        );
         Self::new_internal(event_loop, surface, renderer)
     }
 
@@ -105,7 +117,8 @@ impl Gui {
         renderer: Renderer,
     ) -> Gui {
         let max_texture_side =
-            renderer.queue().device().physical_device().properties().max_image_array_layers as usize;
+            renderer.queue().device().physical_device().properties().max_image_array_layers
+                as usize;
         let mut egui_winit = egui_winit::State::new(event_loop);
         egui_winit.set_max_texture_side(max_texture_side);
         egui_winit.set_pixels_per_point(surface_window(&surface).scale_factor() as f32);

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -29,9 +29,11 @@ use crate::{
 
 pub struct GuiConfig {
     /// Allows supplying sRGB ImageViews as render targets instead of just UNORM ImageViews, defaults to false.
-    /// Using sRGB render targets **will break blending** of UI elements, resulting in potential color differences
-    /// compared to "correct" UNORM render targets.
-    /// If you would like to visually compare between UNORM and sRGB render targets, run the `demo_app` example of our crate.
+    /// **Using sRGB will cause minor discoloration of UI elements** due to blending in linear color space and not
+    /// sRGB as Egui expects.
+    ///
+    /// If you would like to visually compare between UNORM and sRGB render targets, run the `demo_app` example of
+    /// this crate.
     pub allow_srgb_render_target: bool,
     /// Whether to render gui as overlay. Only relevant in the case of `Gui::new`, not when using
     /// subpass. Determines whether the pipeline should clear the target image.
@@ -56,9 +58,10 @@ impl GuiConfig {
         if output_format.type_color().unwrap() == NumericType::SRGB {
             assert!(
                 self.allow_srgb_render_target,
-                "Using an output format with sRGB requires GuiConfig::allow_srgb_render_target to \
-                 be set! This ensures the user is aware that rendering to an sRGB render target \
-                 will breaking blending causing discoloration of UI elements"
+                "Using an output format with sRGB requires `GuiConfig::allow_srgb_render_target` \
+                 to be set! Egui prefers UNORM render targets. Using sRGB will cause minor \
+                 discoloration of UI elements due to blending in linear color space and not sRGB \
+                 as Egui expects."
             );
         }
     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -759,11 +759,13 @@ layout(push_constant) uniform PushConstants {
 } push_constants;
 
 void main() {
-  gl_Position =
-      vec4(2.0 * position.x / push_constants.screen_size.x - 1.0,
-           2.0 * position.y / push_constants.screen_size.y - 1.0, 0.0, 1.0);
-  v_color = color;
-  v_tex_coords = tex_coords;
+    gl_Position = vec4(
+        2.0 * position.x / push_constants.screen_size.x - 1.0,
+        2.0 * position.y / push_constants.screen_size.y - 1.0,
+        0.0, 1.0
+    );
+    v_color = color;
+    v_tex_coords = tex_coords;
 }"
     }
 }
@@ -787,28 +789,30 @@ layout(push_constant) uniform PushConstants {
     int need_srgb_conv;
 } push_constants;
 
-// 0-255 sRGB  from  0-1 linear
-vec3 srgb_from_linear(vec3 rgb) {
-  bvec3 cutoff = lessThan(rgb, vec3(0.0031308));
-  vec3 lower = rgb * vec3(3294.6);
-  vec3 higher = vec3(269.025) * pow(rgb, vec3(1.0 / 2.4)) - vec3(14.025);
-  return mix(higher, lower, vec3(cutoff));
+// 0-1 sRGB  from  0-1 linear
+vec3 srgb_from_linear(vec3 linear) {
+    bvec3 cutoff = lessThan(linear, vec3(0.0031308));
+    vec3 lower = linear * vec3(12.92);
+    vec3 higher = vec3(1.055) * pow(linear, vec3(1./2.4)) - vec3(0.055);
+    return mix(higher, lower, vec3(cutoff));
 }
 
-vec4 srgba_from_linear(vec4 rgba) {
-  return vec4(srgb_from_linear(rgba.rgb), 255.0 * rgba.a);
+// 0-1 sRGBA  from  0-1 linear
+vec4 srgba_from_linear(vec4 linear) {
+    return vec4(srgb_from_linear(linear.rgb), linear.a);
 }
 
-// 0-1 linear  from  0-255 sRGB
+// 0-1 linear  from  0-1 sRGB
 vec3 linear_from_srgb(vec3 srgb) {
-    bvec3 cutoff = lessThan(srgb, vec3(10.31475));
-    vec3 lower = srgb / vec3(3294.6);
-    vec3 higher = pow((srgb + vec3(14.025)) / vec3(269.025), vec3(2.4));
-    return mix(higher, lower, cutoff);
+    bvec3 cutoff = lessThan(srgb, vec3(0.04045));
+    vec3 lower = srgb / vec3(12.92);
+    vec3 higher = pow((srgb + vec3(0.055) / vec3(1.055)), vec3(2.4));
+    return mix(higher, lower, vec3(cutoff));
 }
 
-vec4 linear_from_srgba(vec4 srgba) {
-    return vec4(linear_from_srgb(srgba.rgb * 255.0), srgba.a);
+// 0-1 linear  from  0-1 sRGB
+vec4 linear_from_srgba(vec4 srgb) {
+    return vec4(linear_from_srgb(srgb.rgb), srgb.a);
 }
 
 void main() {
@@ -816,7 +820,7 @@ void main() {
     // We must convert vertex color to linear AFTER interpolation happened
     vec4 color = linear_from_srgba(v_color);
 
-    f_color = srgba_from_linear(color * texture_color) / 255.0;
+    f_color = srgba_from_linear(color * texture_color);
 }"
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -816,11 +816,9 @@ vec4 linear_from_srgba(vec4 srgb) {
 }
 
 void main() {
-    vec4 texture_color = texture(font_texture, v_tex_coords);
-    // We must convert vertex color to linear AFTER interpolation happened
-    vec4 color = linear_from_srgba(v_color);
-
-    f_color = srgba_from_linear(color * texture_color);
+    // ALL calculations are done in gamma space, this includes texture * color and blending
+    vec4 texture_color = srgba_from_linear(texture(font_texture, v_tex_coords));
+    f_color = v_color * texture_color;
 }"
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -758,24 +758,11 @@ layout(push_constant) uniform PushConstants {
     int need_srgb_conv;
 } push_constants;
 
-// 0-1 linear  from  0-255 sRGB
-vec3 linear_from_srgb(vec3 srgb) {
-    bvec3 cutoff = lessThan(srgb, vec3(10.31475));
-    vec3 lower = srgb / vec3(3294.6);
-    vec3 higher = pow((srgb + vec3(14.025)) / vec3(269.025), vec3(2.4));
-    return mix(higher, lower, cutoff);
-}
-
-vec4 linear_from_srgba(vec4 srgba) {
-    return vec4(linear_from_srgb(srgba.rgb * 255.0), srgba.a);
-}
-
 void main() {
   gl_Position =
       vec4(2.0 * position.x / push_constants.screen_size.x - 1.0,
            2.0 * position.y / push_constants.screen_size.y - 1.0, 0.0, 1.0);
-  // We must convert vertex color to linear
-  v_color = linear_from_srgba(color);
+  v_color = color;
   v_tex_coords = tex_coords;
 }"
     }
@@ -826,11 +813,13 @@ vec4 linear_from_srgba(vec4 srgba) {
 
 void main() {
     vec4 texture_color = texture(font_texture, v_tex_coords);
+    // We must convert vertex color to linear AFTER interpolation happened
+    vec4 color = linear_from_srgba(v_color);
 
     if (push_constants.need_srgb_conv == 0) {
-        f_color = v_color * texture_color;
+        f_color = color * texture_color;
     } else {
-        f_color = srgba_from_linear(v_color * texture_color) / 255.0;
+        f_color = srgba_from_linear(color * texture_color) / 255.0;
         f_color.a = pow(f_color.a, 1.6);
     }
 }"

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -816,11 +816,7 @@ void main() {
     // We must convert vertex color to linear AFTER interpolation happened
     vec4 color = linear_from_srgba(v_color);
 
-    if (push_constants.need_srgb_conv == 0) {
-        f_color = color * texture_color;
-    } else {
-        f_color = srgba_from_linear(color * texture_color) / 255.0;
-    }
+    f_color = srgba_from_linear(color * texture_color) / 255.0;
 }"
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -157,7 +157,8 @@ impl Renderer {
         render_pass: Option<Arc<RenderPass>>,
         is_overlay: bool,
     ) -> Renderer {
-        let output_in_linear_colorspace = final_output_format.type_color().unwrap() == NumericType::SRGB;
+        let output_in_linear_colorspace =
+            final_output_format.type_color().unwrap() == NumericType::SRGB;
         let allocators = Allocators::new_default(gfx_queue.device());
         let (vertex_buffer_pool, index_buffer_pool) = Self::create_buffers(&allocators.memory);
         let pipeline = Self::create_pipeline(gfx_queue.clone(), subpass.clone());

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -820,7 +820,6 @@ void main() {
         f_color = color * texture_color;
     } else {
         f_color = srgba_from_linear(color * texture_color) / 255.0;
-        f_color.a = pow(f_color.a, 1.6);
     }
 }"
     }


### PR DESCRIPTION
This is how the sRGB color test things look like on the `master` branch right now on Linux KDE Plasma X11, RADV. This is in sRGB colorspace rendertarget, but looks similarly with a sRGB RT.
![image](https://github.com/hakolao/egui_winit_vulkano/assets/31222740/da68b124-38cc-43fb-9153-d5f014332e20)

This branch **changes the shaders** to fix the colorspace transformations. This image is however in linear color space, as opposed to sRGB.
![image](https://github.com/hakolao/egui_winit_vulkano/assets/31222740/791377c9-8231-4e12-b83b-02d633f8f1c9)