### PR TITLE
Update to Vulkano 0.34

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,8 @@ egui = "0.22"
 egui-winit = "0.22"
 image = "0.24.5"
 winit = "0.28.2"
-#vulkano = "0.34"
-vulkano = { version = "0.34", features = ["serde"] }
+vulkano = "0.34"
 vulkano-shaders = "0.34"
-smallvec = "*"
 
 [dev-dependencies]
 cgmath = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egui_winit_vulkano"
 version = "0.25.0"
 authors = ["hakolao <okkohakola@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Egui immediate mode gui integration with winit and Vulkano"
 homepage = "https://github.com/hakolao/egui_winit_vulkano"
 license = "Apache-2.0"
@@ -22,10 +22,12 @@ egui = "0.22"
 egui-winit = "0.22"
 image = "0.24.5"
 winit = "0.28.2"
-vulkano = "0.33"
-vulkano-shaders = "0.33"
+#vulkano = "0.34"
+vulkano = { version = "0.34", features = ["serde"] }
+vulkano-shaders = "0.34"
+smallvec = "*"
 
 [dev-dependencies]
 cgmath = "0.18.0"
 egui_demo_lib = "0.22"
-vulkano-util = "0.33"
+vulkano-util = "0.34"

--- a/examples/demo_app.rs
+++ b/examples/demo_app.rs
@@ -35,7 +35,7 @@ pub fn main() {
             ..WindowDescriptor::default()
         },
         |ci| {
-            ci.image_format = Some(vulkano::format::Format::B8G8R8A8_SRGB);
+            ci.image_format = vulkano::format::Format::B8G8R8A8_SRGB;
             ci.min_image_count = ci.min_image_count.max(2);
         },
     );
@@ -47,7 +47,7 @@ pub fn main() {
             ..WindowDescriptor::default()
         },
         |ci| {
-            ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
+            ci.image_format = vulkano::format::Format::B8G8R8A8_UNORM;
             ci.min_image_count = ci.min_image_count.max(2);
         },
     );

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -32,7 +32,7 @@ pub fn main() {
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
     windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
+        ci.image_format = vulkano::format::Format::B8G8R8A8_UNORM;
         ci.min_image_count = ci.min_image_count.max(2);
     });
     // Create gui as main render pass (no overlay means it clears the image each frame)

--- a/examples/multisample.rs
+++ b/examples/multisample.rs
@@ -199,8 +199,7 @@ impl MSAAPipeline {
                     image_type: ImageType::Dim2d,
                     format: image_format,
                     extent: [1, 1, 1],
-                    // transient_multisampled
-                    usage: ImageUsage::COLOR_ATTACHMENT | ImageUsage::SAMPLED,
+                    usage: ImageUsage::COLOR_ATTACHMENT | ImageUsage::TRANSIENT_ATTACHMENT,
                     samples: sample_count,
                     ..Default::default()
                 },

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -13,7 +13,7 @@ use egui::{mutex::Mutex, vec2, PaintCallback, PaintCallbackInfo, Rgba, Sense};
 use egui_winit_vulkano::{CallbackContext, CallbackFn, Gui, GuiConfig, RenderResources};
 use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage},
+    memory::allocator::{AllocationCreateInfo},
     pipeline::{
         graphics::{
             depth_stencil::DepthStencilState, input_assembly::InputAssemblyState,
@@ -22,6 +22,14 @@ use vulkano::{
         GraphicsPipeline,
     },
 };
+use vulkano::memory::allocator::MemoryTypeFilter;
+use vulkano::pipeline::graphics::GraphicsPipelineCreateInfo;
+use vulkano::pipeline::graphics::vertex_input::VertexDefinition;
+use vulkano::pipeline::{DynamicState, PipelineLayout, PipelineShaderStageCreateInfo};
+use vulkano::pipeline::graphics::color_blend::{ColorBlendAttachmentState, ColorBlendState};
+use vulkano::pipeline::graphics::multisample::MultisampleState;
+use vulkano::pipeline::graphics::rasterization::RasterizationState;
+use vulkano::pipeline::layout::PipelineDescriptorSetLayoutCreateInfo;
 use vulkano_util::{
     context::{VulkanoConfig, VulkanoContext},
     window::{VulkanoWindows, WindowDescriptor},
@@ -43,7 +51,7 @@ pub fn main() {
         &context,
         &WindowDescriptor { width: 400.0, height: 400.0, ..Default::default() },
         |ci| {
-            ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
+            ci.image_format = vulkano::format::Format::B8G8R8A8_UNORM;
             ci.min_image_count = ci.min_image_count.max(2);
         },
     );
@@ -136,9 +144,13 @@ impl Scene {
     pub fn new(resources: RenderResources) -> Self {
         // Create the vertex buffer for the triangle
         let vertex_buffer = Buffer::from_iter(
-            &resources.memory_allocator,
+            resources.memory_allocator.clone(),
             BufferCreateInfo { usage: BufferUsage::VERTEX_BUFFER, ..Default::default() },
-            AllocationCreateInfo { usage: MemoryUsage::Upload, ..Default::default() },
+            AllocationCreateInfo {
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_RANDOM_ACCESS,
+                ..Default::default()
+            },
             [
                 MyVertex { position: [-0.5, -0.25], color: [1.0, 0.0, 0.0, 1.0] },
                 MyVertex { position: [0.0, 0.5], color: [0.0, 1.0, 0.0, 1.0] },
@@ -149,19 +161,58 @@ impl Scene {
 
         // Create the graphics pipeline
         let vs =
-            vs::load(resources.queue.device().clone()).expect("failed to create shader module");
+            vs::load(resources.queue.device().clone()).expect("failed to create shader module").entry_point("main").unwrap();
         let fs =
-            fs::load(resources.queue.device().clone()).expect("failed to create shader module");
+            fs::load(resources.queue.device().clone()).expect("failed to create shader module").entry_point("main").unwrap();
 
-        let pipeline = GraphicsPipeline::start()
-            .vertex_input_state(MyVertex::per_vertex())
-            .vertex_shader(vs.entry_point("main").unwrap(), ())
-            .input_assembly_state(InputAssemblyState::new())
-            .fragment_shader(fs.entry_point("main").unwrap(), ())
-            .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
-            .depth_stencil_state(DepthStencilState::simple_depth_test())
-            .render_pass(resources.subpass)
-            .build(resources.queue.device().clone())
+        let vertex_input_state = MyVertex::per_vertex()
+            .definition(&vs.info().input_interface)
+            .unwrap();
+
+        let stages = [
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
+        ];
+
+        let layout = PipelineLayout::new(
+            resources.queue.device().clone(),
+            PipelineDescriptorSetLayoutCreateInfo::from_stages(&stages)
+                .into_pipeline_layout_create_info(resources.queue.device().clone())
+                .unwrap(),
+        )
+            .unwrap();
+
+        // let pipeline = GraphicsPipeline::start()
+        //     .vertex_input_state(MyVertex::per_vertex())
+        //     .vertex_shader(vs.entry_point("main").unwrap(), ())
+        //     .input_assembly_state(InputAssemblyState::new())
+        //     .fragment_shader(fs.entry_point("main").unwrap(), ())
+        //     .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
+        //     .depth_stencil_state(DepthStencilState::simple_depth_test())
+        //     .render_pass(resources.subpass)
+        //     .build(resources.queue.device().clone())
+        //     .unwrap();
+        let pipeline = GraphicsPipeline::new(
+            resources.queue.device().clone(),
+            None,
+            GraphicsPipelineCreateInfo {
+                stages: stages.into_iter().collect(),
+                vertex_input_state: Some(vertex_input_state),
+                input_assembly_state: Some(InputAssemblyState::default()),
+                viewport_state: Some(ViewportState::default()),
+                rasterization_state: Some(RasterizationState::default()),
+                multisample_state: Some(
+                    MultisampleState::default()
+                ),
+                color_blend_state: Some(ColorBlendState::with_attachment_states(
+                    resources.subpass.num_color_attachments(),
+                    ColorBlendAttachmentState::default()
+                )),
+                dynamic_state: [DynamicState::Viewport].into_iter().collect(),
+                subpass: Some(resources.subpass.clone().into()),
+                ..GraphicsPipelineCreateInfo::layout(layout)
+            },
+        )
             .unwrap();
 
         // Create scene object
@@ -173,7 +224,9 @@ impl Scene {
         context
             .builder
             .bind_pipeline_graphics(self.pipeline.clone())
+            .unwrap()
             .bind_vertex_buffers(0, self.vertex_buffer.clone())
+            .unwrap()
             .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
             .unwrap();
     }

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -11,23 +11,21 @@ use std::{convert::TryInto, sync::Arc};
 
 use egui::{mutex::Mutex, vec2, PaintCallback, PaintCallbackInfo, Rgba, Sense};
 use egui_winit_vulkano::{CallbackContext, CallbackFn, Gui, GuiConfig, RenderResources};
-use vulkano::memory::allocator::MemoryTypeFilter;
-use vulkano::pipeline::graphics::color_blend::{ColorBlendAttachmentState, ColorBlendState};
-use vulkano::pipeline::graphics::multisample::MultisampleState;
-use vulkano::pipeline::graphics::rasterization::RasterizationState;
-use vulkano::pipeline::graphics::vertex_input::VertexDefinition;
-use vulkano::pipeline::graphics::GraphicsPipelineCreateInfo;
-use vulkano::pipeline::layout::PipelineDescriptorSetLayoutCreateInfo;
-use vulkano::pipeline::{DynamicState, PipelineLayout, PipelineShaderStageCreateInfo};
 use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
-    memory::allocator::AllocationCreateInfo,
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter},
     pipeline::{
         graphics::{
+            color_blend::{ColorBlendAttachmentState, ColorBlendState},
             input_assembly::InputAssemblyState,
-            vertex_input::Vertex, viewport::ViewportState,
+            multisample::MultisampleState,
+            rasterization::RasterizationState,
+            vertex_input::{Vertex, VertexDefinition},
+            viewport::ViewportState,
+            GraphicsPipelineCreateInfo,
         },
-        GraphicsPipeline,
+        layout::PipelineDescriptorSetLayoutCreateInfo,
+        DynamicState, GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
 };
 use vulkano_util::{

--- a/examples/subpass.rs
+++ b/examples/subpass.rs
@@ -327,7 +327,6 @@ impl SimpleGuiPipeline {
         builder.execute_commands(cb).unwrap();
 
         // Move on to next subpass for gui
-        // builder.next_subpass(SubpassContents::SecondaryCommandBuffers).unwrap();
         builder
             .next_subpass(Default::default(), SubpassBeginInfo {
                 contents: SubpassContents::SecondaryCommandBuffers,

--- a/examples/subpass.rs
+++ b/examples/subpass.rs
@@ -24,8 +24,8 @@ use vulkano::{
     },
     device::{Device, Queue},
     format::Format,
-    image::{ImageAccess, SampleCount},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    image::{SampleCount},
+    memory::allocator::{AllocationCreateInfo, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             input_assembly::InputAssemblyState,
@@ -38,9 +38,18 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sync::GpuFuture,
 };
+use vulkano::command_buffer::allocator::StandardCommandBufferAllocatorCreateInfo;
+use vulkano::command_buffer::SubpassBeginInfo;
+use vulkano::image::view::ImageView;
+use vulkano::memory::allocator::MemoryTypeFilter;
+use vulkano::pipeline::graphics::color_blend::{ColorBlendAttachmentState, ColorBlendState};
+use vulkano::pipeline::graphics::GraphicsPipelineCreateInfo;
+use vulkano::pipeline::graphics::rasterization::RasterizationState;
+use vulkano::pipeline::graphics::vertex_input::VertexDefinition;
+use vulkano::pipeline::{DynamicState, PipelineLayout, PipelineShaderStageCreateInfo};
+use vulkano::pipeline::layout::PipelineDescriptorSetLayoutCreateInfo;
 use vulkano_util::{
     context::{VulkanoConfig, VulkanoContext},
-    renderer::SwapchainImageView,
     window::{VulkanoWindows, WindowDescriptor},
 };
 use winit::{
@@ -57,7 +66,7 @@ pub fn main() {
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
     windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
+        ci.image_format = vulkano::format::Format::B8G8R8A8_UNORM;
         ci.min_image_count = ci.min_image_count.max(2);
     });
     // Create out gui pipeline
@@ -150,16 +159,20 @@ impl SimpleGuiPipeline {
     pub fn new(
         queue: Arc<Queue>,
         image_format: vulkano::format::Format,
-        allocator: &StandardMemoryAllocator,
+        allocator: &Arc<StandardMemoryAllocator>,
     ) -> Self {
         let render_pass = Self::create_render_pass(queue.device().clone(), image_format);
         let (pipeline, subpass) =
             Self::create_pipeline(queue.device().clone(), render_pass.clone());
 
         let vertex_buffer = Buffer::from_iter(
-            allocator,
+            allocator.clone(),
             BufferCreateInfo { usage: BufferUsage::VERTEX_BUFFER, ..Default::default() },
-            AllocationCreateInfo { usage: MemoryUsage::Upload, ..Default::default() },
+            AllocationCreateInfo {
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_RANDOM_ACCESS,
+                ..Default::default()
+            },
             [
                 MyVertex { position: [-0.5, -0.25], color: [1.0, 0.0, 0.0, 1.0] },
                 MyVertex { position: [0.0, 0.5], color: [0.0, 1.0, 0.0, 1.0] },
@@ -170,7 +183,10 @@ impl SimpleGuiPipeline {
 
         // Create an allocator for command-buffer data
         let command_buffer_allocator =
-            StandardCommandBufferAllocator::new(queue.device().clone(), Default::default());
+            StandardCommandBufferAllocator::new(queue.device().clone(), StandardCommandBufferAllocatorCreateInfo {
+                secondary_buffer_count: 32,
+                ..Default::default()
+            });
 
         Self { queue, render_pass, pipeline, subpass, vertex_buffer, command_buffer_allocator }
     }
@@ -180,10 +196,10 @@ impl SimpleGuiPipeline {
             device,
             attachments: {
                 color: {
-                    load: Clear,
-                    store: Store,
                     format: format,
                     samples: SampleCount::Sample1,
+                    load_op: Clear,
+                    store_op: Store,
                 }
             },
             passes: [
@@ -202,24 +218,65 @@ impl SimpleGuiPipeline {
         device: Arc<Device>,
         render_pass: Arc<RenderPass>,
     ) -> (Arc<GraphicsPipeline>, Subpass) {
-        let vs = vs::load(device.clone()).expect("failed to create shader module");
-        let fs = fs::load(device.clone()).expect("failed to create shader module");
+        let vs = vs::load(device.clone()).expect("failed to create shader module").entry_point("main").unwrap();
+        let fs = fs::load(device.clone()).expect("failed to create shader module").entry_point("main").unwrap();
+
+        let vertex_input_state = MyVertex::per_vertex()
+            .definition(&vs.info().input_interface)
+            .unwrap();
+
+        let stages = [
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
+        ];
+
+        let layout = PipelineLayout::new(
+            device.clone(),
+            PipelineDescriptorSetLayoutCreateInfo::from_stages(&stages)
+                .into_pipeline_layout_create_info(device.clone())
+                .unwrap(),
+        )
+            .unwrap();
+
 
         let subpass = Subpass::from(render_pass, 0).unwrap();
         (
-            GraphicsPipeline::start()
-                .vertex_input_state(MyVertex::per_vertex())
-                .vertex_shader(vs.entry_point("main").unwrap(), ())
-                .input_assembly_state(InputAssemblyState::new())
-                .fragment_shader(fs.entry_point("main").unwrap(), ())
-                .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
-                .render_pass(subpass.clone())
-                .multisample_state(MultisampleState {
-                    rasterization_samples: SampleCount::Sample1,
-                    ..Default::default()
-                })
-                .build(device)
-                .unwrap(),
+            // GraphicsPipeline::start()
+            //     .vertex_input_state(MyVertex::per_vertex())
+            //     .vertex_shader(vs.entry_point("main").unwrap(), ())
+            //     .input_assembly_state(InputAssemblyState::new())
+            //     .fragment_shader(fs.entry_point("main").unwrap(), ())
+            //     .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
+            //     .render_pass(subpass.clone())
+            //     .multisample_state(MultisampleState {
+            //         rasterization_samples: SampleCount::Sample1,
+            //         ..Default::default()
+            //     })
+            //     .build(device)
+            //     .unwrap(),
+
+        GraphicsPipeline::new(
+            device,
+            None,
+            GraphicsPipelineCreateInfo {
+                stages: stages.into_iter().collect(),
+                vertex_input_state: Some(vertex_input_state),
+                input_assembly_state: Some(InputAssemblyState::default()),
+                viewport_state: Some(ViewportState::default()),
+                rasterization_state: Some(RasterizationState::default()),
+                multisample_state: Some(
+                    MultisampleState::default()
+                ),
+                color_blend_state: Some(ColorBlendState::with_attachment_states(
+                    subpass.num_color_attachments(),
+                    ColorBlendAttachmentState::default()
+                )),
+                dynamic_state: [DynamicState::Viewport].into_iter().collect(),
+                subpass: Some(subpass.clone().into()),
+                ..GraphicsPipelineCreateInfo::layout(layout)
+            },
+        )
+            .unwrap(),
             subpass,
         )
     }
@@ -227,7 +284,7 @@ impl SimpleGuiPipeline {
     pub fn render(
         &mut self,
         before_future: Box<dyn GpuFuture>,
-        image: SwapchainImageView,
+        image: Arc<ImageView>,
         gui: &mut Gui,
     ) -> Box<dyn GpuFuture> {
         let mut builder = AutoCommandBufferBuilder::primary(
@@ -237,7 +294,7 @@ impl SimpleGuiPipeline {
         )
         .unwrap();
 
-        let dimensions = image.image().dimensions().width_height();
+        let dimensions = image.image().extent();
         let framebuffer = Framebuffer::new(self.render_pass.clone(), FramebufferCreateInfo {
             attachments: vec![image],
             ..Default::default()
@@ -251,8 +308,10 @@ impl SimpleGuiPipeline {
                     clear_values: vec![Some([0.0, 0.0, 0.0, 1.0].into())],
                     ..RenderPassBeginInfo::framebuffer(framebuffer)
                 },
-                SubpassContents::SecondaryCommandBuffers,
-            )
+                SubpassBeginInfo {
+                    contents: SubpassContents::SecondaryCommandBuffers,
+                    ..Default::default()
+                },            )
             .unwrap();
 
         // Render first draw pass
@@ -268,25 +327,35 @@ impl SimpleGuiPipeline {
         .unwrap();
         secondary_builder
             .bind_pipeline_graphics(self.pipeline.clone())
-            .set_viewport(0, vec![Viewport {
-                origin: [0.0, 0.0],
-                dimensions: [dimensions[0] as f32, dimensions[1] as f32],
-                depth_range: 0.0..1.0,
-            }])
+            .unwrap()
+            .set_viewport(0, [Viewport {
+                offset: [0.0, 0.0],
+                extent: [dimensions[0] as f32, dimensions[1] as f32],
+                depth_range: 0.0..=1.0,
+            }].into_iter().collect())
+            .unwrap()
             .bind_vertex_buffers(0, self.vertex_buffer.clone())
+            .unwrap()
             .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
             .unwrap();
         let cb = secondary_builder.build().unwrap();
         builder.execute_commands(cb).unwrap();
 
         // Move on to next subpass for gui
-        builder.next_subpass(SubpassContents::SecondaryCommandBuffers).unwrap();
+        // builder.next_subpass(SubpassContents::SecondaryCommandBuffers).unwrap();
+        builder                    .next_subpass(
+            Default::default(),
+            SubpassBeginInfo {
+                contents: SubpassContents::SecondaryCommandBuffers,
+                ..Default::default()
+            },
+        ).unwrap();
         // Draw gui on subpass
-        let cb = gui.draw_on_subpass_image(dimensions);
+        let cb = gui.draw_on_subpass_image([dimensions[0], dimensions[1]]);
         builder.execute_commands(cb).unwrap();
 
         // Last end render pass
-        builder.end_render_pass().unwrap();
+        builder.end_render_pass(Default::default()).unwrap();
         let command_buffer = builder.build().unwrap();
         let after_future = before_future.then_execute(self.queue.clone(), command_buffer).unwrap();
 

--- a/examples/wholesome/frame_system.rs
+++ b/examples/wholesome/frame_system.rs
@@ -20,11 +20,14 @@ use vulkano::{
         RenderPassBeginInfo, SecondaryCommandBufferAbstract, SubpassContents,
     },
     device::Queue,
-    format::Format,
-    image::{view::ImageView, AttachmentImage, ImageAccess, ImageViewAbstract},
+    image::{view::ImageView},
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sync::GpuFuture,
 };
+use vulkano::command_buffer::SubpassBeginInfo;
+use vulkano::format::Format;
+use vulkano::image::{Image, ImageCreateInfo, ImageType, ImageUsage};
+use vulkano::memory::allocator::AllocationCreateInfo;
 
 use crate::renderer::Allocators;
 
@@ -32,7 +35,7 @@ use crate::renderer::Allocators;
 pub struct FrameSystem {
     gfx_queue: Arc<Queue>,
     render_pass: Arc<RenderPass>,
-    depth_buffer: Arc<ImageView<AttachmentImage>>,
+    depth_buffer: Arc<ImageView>,
     allocators: Allocators,
 }
 
@@ -45,16 +48,16 @@ impl FrameSystem {
         let render_pass = vulkano::ordered_passes_renderpass!(gfx_queue.device().clone(),
             attachments: {
                 final_color: {
-                    load: Clear,
-                    store: Store,
                     format: final_output_format,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: Store,
                 },
                 depth: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::D16_UNORM,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 }
             },
             passes: [
@@ -66,15 +69,30 @@ impl FrameSystem {
             ]
         )
         .unwrap();
-        let depth_buffer = ImageView::new_default(
-            AttachmentImage::transient_input_attachment(
-                &allocators.memory,
-                [1, 1],
-                Format::D16_UNORM,
-            )
-            .unwrap(),
-        )
-        .unwrap();
+
+        let depth_buffer = Image::new(
+            allocators.memory.clone(),
+            ImageCreateInfo {
+                image_type: ImageType::Dim2d,
+                format: Format::D16_UNORM,
+                extent: [1, 1, 1],
+                array_layers: 1,
+                usage: ImageUsage::SAMPLED | ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+                ..Default::default()
+            },
+            AllocationCreateInfo::default(),
+        ).unwrap();
+        let depth_buffer = ImageView::new_default(depth_buffer.clone()).unwrap();
+
+        // let depth_buffer = ImageView::new_default(
+        //     AttachmentImage::transient_input_attachment(
+        //         &allocators.memory,
+        //         [1, 1],
+        //         Format::D16_UNORM,
+        //     )
+        //     .unwrap(),
+        // )
+        // .unwrap();
 
         FrameSystem { gfx_queue, render_pass, depth_buffer, allocators }
     }
@@ -87,21 +105,36 @@ impl FrameSystem {
     pub fn frame<F>(
         &mut self,
         before_future: F,
-        final_image: Arc<dyn ImageViewAbstract + 'static>,
+        // final_image: Arc<dyn ImageViewAbstract + 'static>,
+        final_image: Arc<ImageView>,
         world_to_framebuffer: Matrix4<f32>,
     ) -> Frame
     where
         F: GpuFuture + 'static,
     {
-        let img_dims = final_image.image().dimensions().width_height();
-        if self.depth_buffer.image().dimensions().width_height() != img_dims {
+        let img_dims = final_image.image().extent();
+        if self.depth_buffer.image().extent() != img_dims {
             self.depth_buffer = ImageView::new_default(
-                AttachmentImage::transient_input_attachment(
-                    &self.allocators.memory,
-                    img_dims,
-                    Format::D16_UNORM,
-                )
-                .unwrap(),
+                // AttachmentImage::transient_input_attachment(
+                //     &self.allocators.memory,
+                //     img_dims,
+                //     Format::D16_UNORM,
+                // )
+                // .unwrap(),
+
+            Image::new(
+                self.allocators.memory.clone(),
+                ImageCreateInfo {
+                    image_type: ImageType::Dim2d,
+                    format: Format::D16_UNORM,
+                    extent: final_image.image().extent(),
+                    array_layers: 1,
+                    usage: ImageUsage::DEPTH_STENCIL_ATTACHMENT | ImageUsage::TRANSIENT_ATTACHMENT,
+                    ..Default::default()
+                },
+                AllocationCreateInfo::default(),
+            ).unwrap()
+
             )
             .unwrap();
         }
@@ -122,7 +155,10 @@ impl FrameSystem {
                     clear_values: vec![Some([0.0, 0.0, 0.0, 0.0].into()), Some(1.0f32.into())],
                     ..RenderPassBeginInfo::framebuffer(framebuffer.clone())
                 },
-                SubpassContents::SecondaryCommandBuffers,
+                SubpassBeginInfo {
+                    contents: SubpassContents::SecondaryCommandBuffers,
+                    ..Default::default()
+                },
             )
             .unwrap();
 
@@ -156,7 +192,7 @@ impl<'a> Frame<'a> {
         } {
             0 => Some(Pass::Deferred(DrawPass { frame: self })),
             1 => {
-                self.command_buffer_builder.as_mut().unwrap().end_render_pass().unwrap();
+                self.command_buffer_builder.as_mut().unwrap().end_render_pass(Default::default()).unwrap();
                 let command_buffer = self.command_buffer_builder.take().unwrap().build().unwrap();
                 let after_main_cb = self
                     .before_main_cb_future
@@ -182,7 +218,7 @@ pub struct DrawPass<'f, 's: 'f> {
 
 impl<'f, 's: 'f> DrawPass<'f, 's> {
     #[inline]
-    pub fn execute<C>(&mut self, command_buffer: C)
+    pub fn execute<C>(&mut self, command_buffer: Arc<C>)
     where
         C: SecondaryCommandBufferAbstract + Send + Sync + 'static,
     {

--- a/examples/wholesome/frame_system.rs
+++ b/examples/wholesome/frame_system.rs
@@ -14,17 +14,15 @@
 use std::{convert::TryFrom, sync::Arc};
 
 use cgmath::Matrix4;
-use vulkano::command_buffer::SubpassBeginInfo;
-use vulkano::format::Format;
-use vulkano::image::{Image, ImageCreateInfo, ImageType, ImageUsage};
-use vulkano::memory::allocator::AllocationCreateInfo;
 use vulkano::{
     command_buffer::{
         AutoCommandBufferBuilder, CommandBufferUsage, PrimaryAutoCommandBuffer,
-        RenderPassBeginInfo, SecondaryCommandBufferAbstract, SubpassContents,
+        RenderPassBeginInfo, SecondaryCommandBufferAbstract, SubpassBeginInfo, SubpassContents,
     },
     device::Queue,
-    image::view::ImageView,
+    format::Format,
+    image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
+    memory::allocator::AllocationCreateInfo,
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sync::GpuFuture,
 };
@@ -121,13 +119,10 @@ impl FrameSystem {
             )
             .unwrap();
         }
-        let framebuffer = Framebuffer::new(
-            self.render_pass.clone(),
-            FramebufferCreateInfo {
-                attachments: vec![final_image, self.depth_buffer.clone()],
-                ..Default::default()
-            },
-        )
+        let framebuffer = Framebuffer::new(self.render_pass.clone(), FramebufferCreateInfo {
+            attachments: vec![final_image, self.depth_buffer.clone()],
+            ..Default::default()
+        })
         .unwrap();
         let mut command_buffer_builder = AutoCommandBufferBuilder::primary(
             self.allocators.command_buffers.as_ref(),

--- a/examples/wholesome/main.rs
+++ b/examples/wholesome/main.rs
@@ -15,12 +15,16 @@ use egui::{Context, Visuals};
 use egui_winit_vulkano::{Gui, GuiConfig};
 use vulkano::{
     command_buffer::allocator::StandardCommandBufferAllocator,
-    format::Format,
-    image::{ImageUsage, StorageImage},
+    image::{ImageUsage},
 };
+use vulkano::command_buffer::allocator::StandardCommandBufferAllocatorCreateInfo;
+use vulkano::format::Format;
+use vulkano::image::{Image, ImageCreateInfo, ImageType};
+use vulkano::image::view::ImageView;
+use vulkano::memory::allocator::AllocationCreateInfo;
 use vulkano_util::{
     context::{VulkanoConfig, VulkanoContext},
-    renderer::{DeviceImageView, DEFAULT_IMAGE_FORMAT},
+    renderer::{DEFAULT_IMAGE_FORMAT},
     window::{VulkanoWindows, WindowDescriptor},
 };
 use winit::{
@@ -47,7 +51,7 @@ pub struct GuiState {
 }
 
 impl GuiState {
-    pub fn new(gui: &mut Gui, scene_image: DeviceImageView, scene_view_size: [u32; 2]) -> GuiState {
+    pub fn new(gui: &mut Gui, scene_image: Arc<ImageView>, scene_view_size: [u32; 2]) -> GuiState {
         // tree.png asset is from https://github.com/sotrh/learn-wgpu/tree/master/docs/beginner/tutorial5-textures
         let image_texture_id1 = gui.register_user_image(
             include_bytes!("./assets/tree.png"),
@@ -131,7 +135,7 @@ pub fn main() {
     // Vulkano windows (create one)
     let mut windows = VulkanoWindows::default();
     windows.create_window(&event_loop, &context, &WindowDescriptor::default(), |ci| {
-        ci.image_format = Some(vulkano::format::Format::B8G8R8A8_UNORM);
+        ci.image_format = Format::B8G8R8A8_UNORM;
         ci.min_image_count = ci.min_image_count.max(2);
     });
     // Create gui as main render pass (no overlay means it clears the image each frame)
@@ -146,14 +150,28 @@ pub fn main() {
         )
     };
     // Create a simple image to which we'll draw the triangle scene
-    let scene_image = StorageImage::general_purpose_image_view(
-        context.memory_allocator(),
-        context.graphics_queue().clone(),
-        scene_view_size,
-        DEFAULT_IMAGE_FORMAT,
-        ImageUsage::SAMPLED | ImageUsage::COLOR_ATTACHMENT,
-    )
-    .unwrap();
+    // let scene_image = StorageImage::general_purpose_image_view(
+    //     context.memory_allocator(),
+    //     context.graphics_queue().clone(),
+    //     scene_view_size,
+    //     DEFAULT_IMAGE_FORMAT,
+    //     ImageUsage::SAMPLED | ImageUsage::COLOR_ATTACHMENT,
+    // )
+    // .unwrap();
+    let scene_image = Image::new(
+        context.memory_allocator().clone(),
+        ImageCreateInfo {
+            image_type: ImageType::Dim2d,
+            format: DEFAULT_IMAGE_FORMAT,
+            extent: [scene_view_size[0], scene_view_size[1], 1],
+            array_layers: 1,
+            usage: ImageUsage::SAMPLED | ImageUsage::COLOR_ATTACHMENT,
+            ..Default::default()
+        },
+        AllocationCreateInfo::default(),
+    ).unwrap();
+    let scene_image = ImageView::new_default(scene_image.clone()).unwrap();
+
     // Create our render pipeline
     let mut scene_render_pipeline = RenderPipeline::new(
         context.graphics_queue().clone(),
@@ -161,7 +179,10 @@ pub fn main() {
         &renderer::Allocators {
             command_buffers: Arc::new(StandardCommandBufferAllocator::new(
                 context.device().clone(),
-                Default::default(),
+                StandardCommandBufferAllocatorCreateInfo {
+                    secondary_buffer_count: 32,
+                    ..Default::default()
+                },
             )),
             memory: context.memory_allocator().clone(),
         },

--- a/examples/wholesome/main.rs
+++ b/examples/wholesome/main.rs
@@ -13,18 +13,15 @@ use std::sync::Arc;
 
 use egui::{Context, Visuals};
 use egui_winit_vulkano::{Gui, GuiConfig};
-use vulkano::{
-    command_buffer::allocator::StandardCommandBufferAllocator,
-    image::{ImageUsage},
-};
 use vulkano::command_buffer::allocator::StandardCommandBufferAllocatorCreateInfo;
 use vulkano::format::Format;
-use vulkano::image::{Image, ImageCreateInfo, ImageType};
 use vulkano::image::view::ImageView;
+use vulkano::image::{Image, ImageCreateInfo, ImageType};
 use vulkano::memory::allocator::AllocationCreateInfo;
+use vulkano::{command_buffer::allocator::StandardCommandBufferAllocator, image::ImageUsage};
 use vulkano_util::{
     context::{VulkanoConfig, VulkanoContext},
-    renderer::{DEFAULT_IMAGE_FORMAT},
+    renderer::DEFAULT_IMAGE_FORMAT,
     window::{VulkanoWindows, WindowDescriptor},
 };
 use winit::{
@@ -150,15 +147,7 @@ pub fn main() {
         )
     };
     // Create a simple image to which we'll draw the triangle scene
-    // let scene_image = StorageImage::general_purpose_image_view(
-    //     context.memory_allocator(),
-    //     context.graphics_queue().clone(),
-    //     scene_view_size,
-    //     DEFAULT_IMAGE_FORMAT,
-    //     ImageUsage::SAMPLED | ImageUsage::COLOR_ATTACHMENT,
-    // )
-    // .unwrap();
-    let scene_image = Image::new(
+    let scene_image = ImageView::new_default(Image::new(
         context.memory_allocator().clone(),
         ImageCreateInfo {
             image_type: ImageType::Dim2d,
@@ -169,8 +158,8 @@ pub fn main() {
             ..Default::default()
         },
         AllocationCreateInfo::default(),
-    ).unwrap();
-    let scene_image = ImageView::new_default(scene_image.clone()).unwrap();
+    )
+    .unwrap()).unwrap();
 
     // Create our render pipeline
     let mut scene_render_pipeline = RenderPipeline::new(

--- a/examples/wholesome/main.rs
+++ b/examples/wholesome/main.rs
@@ -13,12 +13,14 @@ use std::sync::Arc;
 
 use egui::{Context, Visuals};
 use egui_winit_vulkano::{Gui, GuiConfig};
-use vulkano::command_buffer::allocator::StandardCommandBufferAllocatorCreateInfo;
-use vulkano::format::Format;
-use vulkano::image::view::ImageView;
-use vulkano::image::{Image, ImageCreateInfo, ImageType};
-use vulkano::memory::allocator::AllocationCreateInfo;
-use vulkano::{command_buffer::allocator::StandardCommandBufferAllocator, image::ImageUsage};
+use vulkano::{
+    command_buffer::allocator::{
+        StandardCommandBufferAllocator, StandardCommandBufferAllocatorCreateInfo,
+    },
+    format::Format,
+    image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
+    memory::allocator::AllocationCreateInfo,
+};
 use vulkano_util::{
     context::{VulkanoConfig, VulkanoContext},
     renderer::DEFAULT_IMAGE_FORMAT,
@@ -147,19 +149,22 @@ pub fn main() {
         )
     };
     // Create a simple image to which we'll draw the triangle scene
-    let scene_image = ImageView::new_default(Image::new(
-        context.memory_allocator().clone(),
-        ImageCreateInfo {
-            image_type: ImageType::Dim2d,
-            format: DEFAULT_IMAGE_FORMAT,
-            extent: [scene_view_size[0], scene_view_size[1], 1],
-            array_layers: 1,
-            usage: ImageUsage::SAMPLED | ImageUsage::COLOR_ATTACHMENT,
-            ..Default::default()
-        },
-        AllocationCreateInfo::default(),
+    let scene_image = ImageView::new_default(
+        Image::new(
+            context.memory_allocator().clone(),
+            ImageCreateInfo {
+                image_type: ImageType::Dim2d,
+                format: DEFAULT_IMAGE_FORMAT,
+                extent: [scene_view_size[0], scene_view_size[1], 1],
+                array_layers: 1,
+                usage: ImageUsage::SAMPLED | ImageUsage::COLOR_ATTACHMENT,
+                ..Default::default()
+            },
+            AllocationCreateInfo::default(),
+        )
+        .unwrap(),
     )
-    .unwrap()).unwrap();
+    .unwrap();
 
     // Create our render pipeline
     let mut scene_render_pipeline = RenderPipeline::new(

--- a/examples/wholesome/renderer.rs
+++ b/examples/wholesome/renderer.rs
@@ -10,11 +10,9 @@
 use std::sync::Arc;
 
 use cgmath::{Matrix4, SquareMatrix};
-use vulkano::format::Format;
-use vulkano::image::view::ImageView;
 use vulkano::{
-    command_buffer::allocator::StandardCommandBufferAllocator, device::Queue,
-    memory::allocator::StandardMemoryAllocator, sync::GpuFuture,
+    command_buffer::allocator::StandardCommandBufferAllocator, device::Queue, format::Format,
+    image::view::ImageView, memory::allocator::StandardMemoryAllocator, sync::GpuFuture,
 };
 
 use crate::{

--- a/examples/wholesome/renderer.rs
+++ b/examples/wholesome/renderer.rs
@@ -10,12 +10,12 @@
 use std::sync::Arc;
 
 use cgmath::{Matrix4, SquareMatrix};
+use vulkano::format::Format;
+use vulkano::image::view::ImageView;
 use vulkano::{
     command_buffer::allocator::StandardCommandBufferAllocator, device::Queue,
     memory::allocator::StandardMemoryAllocator, sync::GpuFuture,
 };
-use vulkano::format::Format;
-use vulkano::image::view::ImageView;
 
 use crate::{
     frame_system::{FrameSystem, Pass},
@@ -34,11 +34,7 @@ pub struct Allocators {
 }
 
 impl RenderPipeline {
-    pub fn new(
-        queue: Arc<Queue>,
-        image_format: Format,
-        allocators: &Allocators,
-    ) -> Self {
+    pub fn new(queue: Arc<Queue>, image_format: Format, allocators: &Allocators) -> Self {
         let frame_system = FrameSystem::new(queue.clone(), image_format, allocators.clone());
         let draw_pipeline =
             TriangleDrawSystem::new(queue, frame_system.deferred_subpass(), allocators);

--- a/examples/wholesome/triangle_draw_system.rs
+++ b/examples/wholesome/triangle_draw_system.rs
@@ -13,14 +13,6 @@
 
 use std::{convert::TryInto, sync::Arc};
 
-use vulkano::memory::allocator::MemoryTypeFilter;
-use vulkano::pipeline::graphics::color_blend::{ColorBlendAttachmentState, ColorBlendState};
-use vulkano::pipeline::graphics::multisample::MultisampleState;
-use vulkano::pipeline::graphics::rasterization::RasterizationState;
-use vulkano::pipeline::graphics::vertex_input::VertexDefinition;
-use vulkano::pipeline::graphics::GraphicsPipelineCreateInfo;
-use vulkano::pipeline::layout::PipelineDescriptorSetLayoutCreateInfo;
-use vulkano::pipeline::{DynamicState, PipelineLayout, PipelineShaderStageCreateInfo};
 use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
@@ -28,15 +20,20 @@ use vulkano::{
         CommandBufferInheritanceInfo, CommandBufferUsage, SecondaryAutoCommandBuffer,
     },
     device::Queue,
-    memory::allocator::AllocationCreateInfo,
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter},
     pipeline::{
         graphics::{
+            color_blend::{ColorBlendAttachmentState, ColorBlendState},
             depth_stencil::DepthStencilState,
             input_assembly::InputAssemblyState,
-            vertex_input::Vertex,
+            multisample::MultisampleState,
+            rasterization::RasterizationState,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
+            GraphicsPipelineCreateInfo,
         },
-        GraphicsPipeline,
+        layout::PipelineDescriptorSetLayoutCreateInfo,
+        DynamicState, GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
     render_pass::Subpass,
 };
@@ -97,26 +94,22 @@ impl TriangleDrawSystem {
             )
             .unwrap();
 
-            GraphicsPipeline::new(
-                gfx_queue.device().clone(),
-                None,
-                GraphicsPipelineCreateInfo {
-                    stages: stages.into_iter().collect(),
-                    vertex_input_state: Some(vertex_input_state),
-                    input_assembly_state: Some(InputAssemblyState::default()),
-                    viewport_state: Some(ViewportState::default()),
-                    rasterization_state: Some(RasterizationState::default()),
-                    multisample_state: Some(MultisampleState::default()),
-                    color_blend_state: Some(ColorBlendState::with_attachment_states(
-                        subpass.num_color_attachments(),
-                        ColorBlendAttachmentState::default(),
-                    )),
-                    depth_stencil_state: Some(DepthStencilState::default()),
-                    dynamic_state: [DynamicState::Viewport].into_iter().collect(),
-                    subpass: Some(subpass.clone().into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
-                },
-            )
+            GraphicsPipeline::new(gfx_queue.device().clone(), None, GraphicsPipelineCreateInfo {
+                stages: stages.into_iter().collect(),
+                vertex_input_state: Some(vertex_input_state),
+                input_assembly_state: Some(InputAssemblyState::default()),
+                viewport_state: Some(ViewportState::default()),
+                rasterization_state: Some(RasterizationState::default()),
+                multisample_state: Some(MultisampleState::default()),
+                color_blend_state: Some(ColorBlendState::with_attachment_states(
+                    subpass.num_color_attachments(),
+                    ColorBlendAttachmentState::default(),
+                )),
+                depth_stencil_state: Some(DepthStencilState::default()),
+                dynamic_state: [DynamicState::Viewport].into_iter().collect(),
+                subpass: Some(subpass.clone().into()),
+                ..GraphicsPipelineCreateInfo::layout(layout)
+            })
             .unwrap()
         };
 

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -13,13 +13,15 @@ use egui_winit::winit::event_loop::EventLoopWindowTarget;
 use vulkano::{
     command_buffer::SecondaryAutoCommandBuffer,
     device::Queue,
-    format::{Format, NumericType},
-    image::{ImageViewAbstract, SampleCount},
+    format::{Format},
+    image::{SampleCount},
     render_pass::Subpass,
-    sampler::SamplerCreateInfo,
     swapchain::Surface,
     sync::GpuFuture,
 };
+use vulkano::format::NumericFormat;
+use vulkano::image::sampler::SamplerCreateInfo;
+use vulkano::image::view::ImageView;
 use winit::window::Window;
 
 use crate::{
@@ -55,7 +57,8 @@ impl Default for GuiConfig {
 
 impl GuiConfig {
     pub fn validate(&self, output_format: Format) {
-        if output_format.type_color().unwrap() == NumericType::SRGB {
+        // if output_format.type_color().unwrap() == NumericType::SRGB {
+        if output_format.numeric_format_color().unwrap() == NumericFormat::SRGB {
             assert!(
                 self.allow_srgb_render_target,
                 "Using an output format with sRGB requires `GuiConfig::allow_srgb_render_target` \
@@ -174,10 +177,11 @@ impl Gui {
     pub fn draw_on_image<F>(
         &mut self,
         before_future: F,
-        final_image: Arc<dyn ImageViewAbstract + 'static>,
+        // final_image: Arc<dyn ImageViewAbstract + 'static>,
+        final_image: Arc<ImageView>,
     ) -> Box<dyn GpuFuture>
-    where
-        F: GpuFuture + 'static,
+        where
+            F: GpuFuture + 'static,
     {
         if !self.renderer.has_renderpass() {
             panic!(
@@ -203,7 +207,7 @@ impl Gui {
     pub fn draw_on_subpass_image(
         &mut self,
         image_dimensions: [u32; 2],
-    ) -> SecondaryAutoCommandBuffer {
+    ) -> Arc<SecondaryAutoCommandBuffer> {
         if self.renderer.has_renderpass() {
             panic!(
                 "Gui integration has been created with its own render pass, use `draw_on_image` \
@@ -245,7 +249,8 @@ impl Gui {
     /// Registers a user image from Vulkano image view to be used by egui
     pub fn register_user_image_view(
         &mut self,
-        image: Arc<dyn ImageViewAbstract + Send + Sync>,
+        // image: Arc<dyn ImageViewAbstract + Send + Sync>,
+        image: Arc<ImageView>,
         sampler_create_info: SamplerCreateInfo,
     ) -> egui::TextureId {
         self.renderer.register_image(image, sampler_create_info)
@@ -266,7 +271,7 @@ impl Gui {
             image_file_bytes,
             format,
         )
-        .expect("Failed to create image");
+            .expect("Failed to create image");
         self.renderer.register_image(image, sampler_create_info)
     }
 
@@ -284,7 +289,7 @@ impl Gui {
             dimensions,
             format,
         )
-        .expect("Failed to create image");
+            .expect("Failed to create image");
         self.renderer.register_image(image, sampler_create_info)
     }
 

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -10,18 +10,13 @@ use std::sync::Arc;
 
 use egui::{ClippedPrimitive, TexturesDelta};
 use egui_winit::winit::event_loop::EventLoopWindowTarget;
-use vulkano::{
-    command_buffer::SecondaryAutoCommandBuffer,
-    device::Queue,
-    format::{Format},
-    image::{SampleCount},
-    render_pass::Subpass,
-    swapchain::Surface,
-    sync::GpuFuture,
-};
 use vulkano::format::NumericFormat;
 use vulkano::image::sampler::SamplerCreateInfo;
 use vulkano::image::view::ImageView;
+use vulkano::{
+    command_buffer::SecondaryAutoCommandBuffer, device::Queue, format::Format, image::SampleCount,
+    render_pass::Subpass, swapchain::Surface, sync::GpuFuture,
+};
 use winit::window::Window;
 
 use crate::{
@@ -180,8 +175,8 @@ impl Gui {
         // final_image: Arc<dyn ImageViewAbstract + 'static>,
         final_image: Arc<ImageView>,
     ) -> Box<dyn GpuFuture>
-        where
-            F: GpuFuture + 'static,
+    where
+        F: GpuFuture + 'static,
     {
         if !self.renderer.has_renderpass() {
             panic!(
@@ -249,7 +244,6 @@ impl Gui {
     /// Registers a user image from Vulkano image view to be used by egui
     pub fn register_user_image_view(
         &mut self,
-        // image: Arc<dyn ImageViewAbstract + Send + Sync>,
         image: Arc<ImageView>,
         sampler_create_info: SamplerCreateInfo,
     ) -> egui::TextureId {
@@ -271,7 +265,7 @@ impl Gui {
             image_file_bytes,
             format,
         )
-            .expect("Failed to create image");
+        .expect("Failed to create image");
         self.renderer.register_image(image, sampler_create_info)
     }
 
@@ -289,7 +283,7 @@ impl Gui {
             dimensions,
             format,
         )
-            .expect("Failed to create image");
+        .expect("Failed to create image");
         self.renderer.register_image(image, sampler_create_info)
     }
 

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -10,12 +10,14 @@ use std::sync::Arc;
 
 use egui::{ClippedPrimitive, TexturesDelta};
 use egui_winit::winit::event_loop::EventLoopWindowTarget;
-use vulkano::format::NumericFormat;
-use vulkano::image::sampler::SamplerCreateInfo;
-use vulkano::image::view::ImageView;
 use vulkano::{
-    command_buffer::SecondaryAutoCommandBuffer, device::Queue, format::Format, image::SampleCount,
-    render_pass::Subpass, swapchain::Surface, sync::GpuFuture,
+    command_buffer::SecondaryAutoCommandBuffer,
+    device::Queue,
+    format::{Format, NumericFormat},
+    image::{sampler::SamplerCreateInfo, view::ImageView, SampleCount},
+    render_pass::Subpass,
+    swapchain::Surface,
+    sync::GpuFuture,
 };
 use winit::window::Window;
 

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -54,7 +54,6 @@ impl Default for GuiConfig {
 
 impl GuiConfig {
     pub fn validate(&self, output_format: Format) {
-        // if output_format.type_color().unwrap() == NumericType::SRGB {
         if output_format.numeric_format_color().unwrap() == NumericFormat::SRGB {
             assert!(
                 self.allow_srgb_render_target,
@@ -174,7 +173,6 @@ impl Gui {
     pub fn draw_on_image<F>(
         &mut self,
         before_future: F,
-        // final_image: Arc<dyn ImageViewAbstract + 'static>,
         final_image: Arc<ImageView>,
     ) -> Box<dyn GpuFuture>
     where

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -17,83 +17,50 @@ use egui::{
     epaint::{Mesh, Primitive},
     ClippedPrimitive, PaintCallbackInfo, Rect, TexturesDelta,
 };
-use smallvec::SmallVec;
-// use vulkano::{
-//     buffer::{
-//         allocator::{SubbufferAllocator, SubbufferAllocatorCreateInfo},
-//         Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer,
-//     },
-//     command_buffer::{
-//         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, BlitImageInfo,
-//         CommandBufferInheritanceInfo, CommandBufferUsage, CopyBufferToImageInfo, ImageBlit,
-//         PrimaryAutoCommandBuffer, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
-//         SecondaryAutoCommandBuffer, SubpassContents,
-//     },
-//     descriptor_set::{
-//         allocator::StandardDescriptorSetAllocator, layout::DescriptorSetLayout,
-//         PersistentDescriptorSet, WriteDescriptorSet,
-//     },
-//     device::Queue,
-//     format::{Format},
-//     image::{
-//         view::ImageView, ImageLayout, ImageUsage,
-//         SampleCount,
-//     },
-//     memory::allocator::{AllocationCreateInfo, StandardMemoryAllocator},
-//     pipeline::{
-//         graphics::{
-//             color_blend::{AttachmentBlend, BlendFactor, ColorBlendState},
-//             input_assembly::InputAssemblyState,
-//             multisample::MultisampleState,
-//             rasterization::{RasterizationState},
-//             vertex_input::Vertex,
-//             viewport::{Scissor, Viewport, ViewportState},
-//         },
-//         GraphicsPipeline, Pipeline, PipelineBindPoint,
-//     },
-//     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
-//     sync::{self, GpuFuture},
-//     DeviceSize,
-// };
-// use vulkano::command_buffer::SubpassBeginInfo;
-// use vulkano::format::NumericFormat;
-// use vulkano::image::{Image, ImageCreateInfo, ImageType};
-// use vulkano::image::sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo, SamplerMipmapMode};
-// use vulkano::pipeline::graphics::GraphicsPipelineCreateInfo;
-// use vulkano::pipeline::graphics::vertex_input::VertexDefinition;
-// use vulkano::pipeline::{PipelineLayout, PipelineShaderStageCreateInfo};
-// use vulkano::pipeline::graphics::color_blend::ColorBlendAttachmentState;
-// use vulkano::pipeline::layout::PipelineDescriptorSetLayoutCreateInfo;
-use vulkano::{buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage}, command_buffer::{
-    allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-    RenderPassBeginInfo, SubpassBeginInfo, SubpassContents,
-}, DeviceSize, image::{view::ImageView, Image, ImageUsage}, memory::allocator::{AllocationCreateInfo, StandardMemoryAllocator}, pipeline::{
-    graphics::{
-        color_blend::{ColorBlendAttachmentState, ColorBlendState},
-        input_assembly::InputAssemblyState,
-        multisample::MultisampleState,
-        rasterization::RasterizationState,
-        vertex_input::{Vertex, VertexDefinition},
-        viewport::{Viewport, ViewportState},
-        GraphicsPipelineCreateInfo,
-    },
-    layout::PipelineDescriptorSetLayoutCreateInfo,
-    GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
-}, render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass}, sync::{ GpuFuture}};
 use vulkano::buffer::allocator::{SubbufferAllocator, SubbufferAllocatorCreateInfo};
 use vulkano::buffer::Subbuffer;
-use vulkano::command_buffer::{BlitImageInfo, CommandBufferInheritanceInfo, CopyBufferToImageInfo, ImageBlit, PrimaryAutoCommandBuffer, PrimaryCommandBufferAbstract, SecondaryAutoCommandBuffer};
+use vulkano::command_buffer::{
+    BlitImageInfo, CommandBufferInheritanceInfo, CopyBufferToImageInfo, ImageBlit,
+    PrimaryAutoCommandBuffer, PrimaryCommandBufferAbstract, SecondaryAutoCommandBuffer,
+};
+use vulkano::descriptor_set::allocator::StandardDescriptorSetAllocator;
 use vulkano::descriptor_set::layout::DescriptorSetLayout;
 use vulkano::descriptor_set::{PersistentDescriptorSet, WriteDescriptorSet};
-use vulkano::descriptor_set::allocator::StandardDescriptorSetAllocator;
 use vulkano::device::Queue;
 use vulkano::format::{Format, NumericFormat};
+use vulkano::image::sampler::{
+    Filter, Sampler, SamplerAddressMode, SamplerCreateInfo, SamplerMipmapMode,
+};
 use vulkano::image::{ImageCreateInfo, ImageLayout, ImageType, SampleCount};
-use vulkano::image::sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo, SamplerMipmapMode};
 use vulkano::memory::allocator::MemoryTypeFilter;
 use vulkano::pipeline::graphics::color_blend::{AttachmentBlend, BlendFactor};
 use vulkano::pipeline::graphics::viewport::Scissor;
-use vulkano::pipeline::{DynamicState, Pipeline, PipelineBindPoint};
+use vulkano::{
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
+    command_buffer::{
+        allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
+        RenderPassBeginInfo, SubpassBeginInfo, SubpassContents,
+    },
+    image::{view::ImageView, Image, ImageUsage},
+    memory::allocator::{AllocationCreateInfo, StandardMemoryAllocator},
+    pipeline::{
+        graphics::{
+            color_blend::{ColorBlendAttachmentState, ColorBlendState},
+            input_assembly::InputAssemblyState,
+            multisample::MultisampleState,
+            rasterization::RasterizationState,
+            vertex_input::{Vertex, VertexDefinition},
+            viewport::{Viewport, ViewportState},
+            GraphicsPipelineCreateInfo,
+        },
+        layout::PipelineDescriptorSetLayoutCreateInfo,
+        DynamicState, GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
+    },
+    render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
+    sync::GpuFuture,
+    DeviceSize,
+};
 
 use crate::utils::Allocators;
 
@@ -130,7 +97,6 @@ pub struct Renderer {
     subpass: Subpass,
 
     texture_desc_sets: AHashMap<egui::TextureId, Arc<PersistentDescriptorSet>>,
-    // texture_images: AHashMap<egui::TextureId, Arc<dyn ImageViewAbstract + Send + Sync + 'static>>,
     texture_images: AHashMap<egui::TextureId, Arc<ImageView>>,
     next_native_tex_id: u64,
 }
@@ -168,7 +134,7 @@ impl Renderer {
                         depth_stencil: {}
                 }
             )
-                .unwrap()
+            .unwrap()
         } else {
             vulkano::single_pass_renderpass!(gfx_queue.device().clone(),
                 attachments: {
@@ -184,7 +150,7 @@ impl Renderer {
                         depth_stencil: {}
                 }
             )
-                .unwrap()
+            .unwrap()
         };
         let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
         Self::new_internal(gfx_queue, final_output_format, subpass, Some(render_pass), is_overlay)
@@ -203,14 +169,17 @@ impl Renderer {
         let allocators = Allocators::new_default(gfx_queue.device());
         let (vertex_buffer_pool, index_buffer_pool) = Self::create_buffers(&allocators.memory);
         let pipeline = Self::create_pipeline(gfx_queue.clone(), subpass.clone());
-        let font_sampler = Sampler::new(gfx_queue.device().clone(), SamplerCreateInfo {
-            mag_filter: Filter::Linear,
-            min_filter: Filter::Linear,
-            address_mode: [SamplerAddressMode::ClampToEdge; 3],
-            mipmap_mode: SamplerMipmapMode::Linear,
-            ..Default::default()
-        })
-            .unwrap();
+        let font_sampler = Sampler::new(
+            gfx_queue.device().clone(),
+            SamplerCreateInfo {
+                mag_filter: Filter::Linear,
+                min_filter: Filter::Linear,
+                address_mode: [SamplerAddressMode::ClampToEdge; 3],
+                mipmap_mode: SamplerMipmapMode::Linear,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         Renderer {
             gfx_queue,
             format: final_output_format,
@@ -237,54 +206,58 @@ impl Renderer {
         allocator: &Arc<StandardMemoryAllocator>,
     ) -> (SubbufferAllocator, SubbufferAllocator) {
         // Create vertex and index buffers
-        let vertex_buffer_pool =
-            SubbufferAllocator::new(allocator.clone(), SubbufferAllocatorCreateInfo {
+        let vertex_buffer_pool = SubbufferAllocator::new(
+            allocator.clone(),
+            SubbufferAllocatorCreateInfo {
                 arena_size: VERTEX_BUFFER_SIZE,
                 buffer_usage: BufferUsage::VERTEX_BUFFER,
-                // memory_usage: MemoryUsage::Upload,
                 memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
                     | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
-            });
+            },
+        );
 
-        let index_buffer_pool =
-            SubbufferAllocator::new(allocator.clone(), SubbufferAllocatorCreateInfo {
+        let index_buffer_pool = SubbufferAllocator::new(
+            allocator.clone(),
+            SubbufferAllocatorCreateInfo {
                 arena_size: INDEX_BUFFER_SIZE,
                 buffer_usage: BufferUsage::INDEX_BUFFER,
-                // memory_usage: MemoryUsage::Upload,
                 memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
                     | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
-            });
+            },
+        );
 
         (vertex_buffer_pool, index_buffer_pool)
     }
 
     fn create_pipeline(gfx_queue: Arc<Queue>, subpass: Subpass) -> Arc<GraphicsPipeline> {
-        let vs = vs::load(gfx_queue.device().clone()).expect("failed to create shader module").entry_point("main").unwrap();
-        let fs = fs::load(gfx_queue.device().clone()).expect("failed to create shader module").entry_point("main").unwrap();
+        let vs = vs::load(gfx_queue.device().clone())
+            .expect("failed to create shader module")
+            .entry_point("main")
+            .unwrap();
+        let fs = fs::load(gfx_queue.device().clone())
+            .expect("failed to create shader module")
+            .entry_point("main")
+            .unwrap();
 
         let mut blend = AttachmentBlend::alpha();
         blend.src_color_blend_factor = BlendFactor::One;
         blend.src_alpha_blend_factor = BlendFactor::OneMinusDstAlpha;
         blend.dst_alpha_blend_factor = BlendFactor::One;
-        // let blend_state = ColorBlendState::new(1).blend(blend);
         let blend_state = ColorBlendState {
-            attachments: vec![
-                ColorBlendAttachmentState {
-                    blend: Some(blend),
-                    ..Default::default()
-                }
-            ],
+            attachments: vec![ColorBlendAttachmentState {
+                blend: Some(blend),
+                ..Default::default()
+            }],
             ..ColorBlendState::default()
         };
 
-        let vertex_input_state = Some(EguiVertex::per_vertex().definition(&vs.info().input_interface).unwrap());
+        let vertex_input_state =
+            Some(EguiVertex::per_vertex().definition(&vs.info().input_interface).unwrap());
 
-        let stages = [
-            PipelineShaderStageCreateInfo::new(vs),
-            PipelineShaderStageCreateInfo::new(fs),
-        ];
+        let stages =
+            [PipelineShaderStageCreateInfo::new(vs), PipelineShaderStageCreateInfo::new(fs)];
 
         let layout = PipelineLayout::new(
             gfx_queue.device().clone(),
@@ -292,7 +265,7 @@ impl Renderer {
                 .into_pipeline_layout_create_info(gfx_queue.device().clone())
                 .unwrap(),
         )
-            .unwrap();
+        .unwrap();
 
         GraphicsPipeline::new(
             gfx_queue.device().clone(),
@@ -304,37 +277,40 @@ impl Renderer {
                 viewport_state: Some(ViewportState::default()),
                 rasterization_state: Some(RasterizationState::default()),
                 multisample_state: Some(MultisampleState {
-                            rasterization_samples: subpass.num_samples().unwrap_or(SampleCount::Sample1),
-                            ..Default::default()
-                        }
-                    ),
+                    rasterization_samples: subpass.num_samples().unwrap_or(SampleCount::Sample1),
+                    ..Default::default()
+                }),
                 color_blend_state: Some(blend_state),
-                dynamic_state: [DynamicState::Viewport, DynamicState::Scissor].into_iter().collect(),
+                dynamic_state: [DynamicState::Viewport, DynamicState::Scissor]
+                    .into_iter()
+                    .collect(),
                 subpass: Some(subpass.into()),
                 ..GraphicsPipelineCreateInfo::layout(layout)
             },
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     /// Creates a descriptor set for images
     fn sampled_image_desc_set(
         &self,
         layout: &Arc<DescriptorSetLayout>,
-        // image: Arc<dyn ImageViewAbstract + 'static>,
         image: Arc<ImageView>,
         sampler: Arc<Sampler>,
     ) -> Arc<PersistentDescriptorSet> {
-        PersistentDescriptorSet::new(&self.allocators.descriptor_set, layout.clone(), [
-            WriteDescriptorSet::image_view_sampler(0, image, sampler),
-        ], [])
-            .unwrap()
+        PersistentDescriptorSet::new(
+            &self.allocators.descriptor_set,
+            layout.clone(),
+            [WriteDescriptorSet::image_view_sampler(0, image, sampler)],
+            [],
+        )
+        .unwrap()
     }
 
     /// Registers a user texture. User texture needs to be unregistered when it is no longer needed
     pub fn register_image(
         &mut self,
         image: Arc<ImageView>,
-        // image: Arc<dyn ImageViewAbstract + Send + Sync>,
         sampler_create_info: SamplerCreateInfo,
     ) -> egui::TextureId {
         let layout = self.pipeline.layout().set_layouts().get(0).unwrap();
@@ -372,14 +348,14 @@ impl Renderer {
         let texture_data_buffer = Buffer::from_iter(
             self.allocators.memory.clone(),
             BufferCreateInfo { usage: BufferUsage::TRANSFER_SRC, ..Default::default() },
-            // AllocationCreateInfo { usage: MemoryUsage::Upload, ..Default::default() },
             AllocationCreateInfo {
                 memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
                     | MemoryTypeFilter::HOST_RANDOM_ACCESS,
                 ..Default::default()
-            },            data,
+            },
+            data,
         )
-            .unwrap();
+        .unwrap();
         // Create image
         let img = {
             let extent = [delta.image.width() as u32, delta.image.height() as u32, 1];
@@ -389,31 +365,18 @@ impl Renderer {
                     image_type: ImageType::Dim2d,
                     format: Format::R8G8B8A8_SRGB,
                     extent,
-                    usage: ImageUsage::TRANSFER_DST | ImageUsage::TRANSFER_SRC | ImageUsage::SAMPLED,
+                    usage: ImageUsage::TRANSFER_DST
+                        | ImageUsage::TRANSFER_SRC
+                        | ImageUsage::SAMPLED,
                     // initial_layout: ImageLayout::ShaderReadOnlyOptimal,
                     // TODO(aedm): miez
                     initial_layout: ImageLayout::Undefined,
                     ..Default::default()
                 },
-                AllocationCreateInfo::default()
-            ).unwrap()
+                AllocationCreateInfo::default(),
+            )
+            .unwrap()
         };
-
-        // let (img, init) = ImmutableImage::uninitialized(
-        //     &self.allocators.memory,
-        //     // vulkano::image::ImageDimensions::Dim2d {
-        //     //     width: delta.image.width() as u32,
-        //     //     height: delta.image.height() as u32,
-        //     //     array_layers: 1,
-        //     // },
-        //     // Format::R8G8B8A8_SRGB,
-        //     // vulkano::image::MipmapsCount::One,
-        //     // ImageUsage::TRANSFER_DST | ImageUsage::TRANSFER_SRC | ImageUsage::SAMPLED,
-        //     // Default::default(),
-        //     // ImageLayout::ShaderReadOnlyOptimal,
-        //     Some(self.gfx_queue.queue_family_index()),
-        // )
-        //     .unwrap();
 
         // Create command buffer builder
         let mut cbb = AutoCommandBufferBuilder::primary(
@@ -421,22 +384,23 @@ impl Renderer {
             self.gfx_queue.queue_family_index(),
             CommandBufferUsage::OneTimeSubmit,
         )
-            .unwrap();
+        .unwrap();
 
         // Copy buffer to image
-        cbb.copy_buffer_to_image(CopyBufferToImageInfo::buffer_image(texture_data_buffer, img.clone()))
-            .unwrap();
+        cbb.copy_buffer_to_image(CopyBufferToImageInfo::buffer_image(
+            texture_data_buffer,
+            img.clone(),
+        ))
+        .unwrap();
 
         let font_image = ImageView::new_default(img).unwrap();
 
         // Blit texture data to existing image if delta pos exists (e.g. font changed)
         if let Some(pos) = delta.pos {
             if let Some(existing_image) = self.texture_images.get(&texture_id) {
-                // let src_dims = font_image.image().dimensions();
                 let src_dims = font_image.image().extent();
                 let top_left = [pos[0] as u32, pos[1] as u32, 0];
                 let bottom_right =
-                    // [pos[0] as u32 + src_dims.width(), pos[1] as u32 + src_dims.height(), 1];
                     [pos[0] as u32 + src_dims[0], pos[1] as u32 + src_dims[1], 1];
 
                 cbb.blit_image(BlitImageInfo {
@@ -444,17 +408,19 @@ impl Renderer {
                     dst_image_layout: ImageLayout::General,
                     regions: [ImageBlit {
                         src_subresource: font_image.image().subresource_layers(),
-                        // src_offsets: [[0, 0, 0], [src_dims.width(), src_dims.height(), 1]],
                         src_offsets: [[0, 0, 0], src_dims],
                         dst_subresource: existing_image.image().subresource_layers(),
                         dst_offsets: [top_left, bottom_right],
                         ..Default::default()
                     }]
-                        .into(),
+                    .into(),
                     filter: Filter::Nearest,
-                    ..BlitImageInfo::images(font_image.image().clone(), existing_image.image().clone())
+                    ..BlitImageInfo::images(
+                        font_image.image().clone(),
+                        existing_image.image().clone(),
+                    )
                 })
-                    .unwrap();
+                .unwrap();
             }
             // Otherwise save the newly created image
         } else {
@@ -537,20 +503,16 @@ impl Renderer {
                 ..Default::default()
             },
         )
-            .unwrap()
+        .unwrap()
     }
 
     // Starts the rendering pipeline and returns [`AutoCommandBufferBuilder`] for drawing
     fn start(
         &mut self,
-        // final_image: Arc<dyn ImageViewAbstract + 'static>,
         final_image: Arc<ImageView>,
     ) -> (AutoCommandBufferBuilder<PrimaryAutoCommandBuffer>, [u32; 2]) {
         // Get dimensions
-        // let img_dims = final_image.image().dimensions().width_height();
         let img_dims = final_image.image().extent();
-        let img_dims = [img_dims[0], img_dims[1]];
-        // let img_dims = [img_dims[0], img_dims[1]];
         // Create framebuffer (must be in same order as render pass description in `new`
         let framebuffer = Framebuffer::new(
             self.render_pass
@@ -562,13 +524,13 @@ impl Renderer {
                 .clone(),
             FramebufferCreateInfo { attachments: vec![final_image], ..Default::default() },
         )
-            .unwrap();
+        .unwrap();
         let mut command_buffer_builder = AutoCommandBufferBuilder::primary(
             &self.allocators.command_buffer,
             self.gfx_queue.queue_family_index(),
             CommandBufferUsage::OneTimeSubmit,
         )
-            .unwrap();
+        .unwrap();
         // Add clear values here for attachments and begin render pass
         command_buffer_builder
             .begin_render_pass(
@@ -576,11 +538,13 @@ impl Renderer {
                     clear_values: vec![if !self.is_overlay { Some([0.0; 4].into()) } else { None }],
                     ..RenderPassBeginInfo::framebuffer(framebuffer)
                 },
-                // SubpassContents::SecondaryCommandBuffers,
-                SubpassBeginInfo { contents: SubpassContents::SecondaryCommandBuffers, ..SubpassBeginInfo::default() },
+                SubpassBeginInfo {
+                    contents: SubpassContents::SecondaryCommandBuffers,
+                    ..SubpassBeginInfo::default()
+                },
             )
             .unwrap();
-        (command_buffer_builder, img_dims)
+        (command_buffer_builder, [img_dims[0], img_dims[1]])
     }
 
     /// Executes our draw commands on the final image and returns a `GpuFuture` to wait on
@@ -590,11 +554,10 @@ impl Renderer {
         textures_delta: &TexturesDelta,
         scale_factor: f32,
         before_future: F,
-        // final_image: Arc<dyn ImageViewAbstract + 'static>,
         final_image: Arc<ImageView>,
     ) -> Box<dyn GpuFuture>
-        where
-            F: GpuFuture + 'static,
+    where
+        F: GpuFuture + 'static,
     {
         for (id, image_delta) in &textures_delta.set {
             self.update_texture(*id, image_delta);
@@ -639,7 +602,6 @@ impl Renderer {
         textures_delta: &TexturesDelta,
         scale_factor: f32,
         framebuffer_dimensions: [u32; 2],
-    // ) -> SecondaryAutoCommandBuffer {
     ) -> Arc<SecondaryAutoCommandBuffer> {
         for (id, image_delta) in &textures_delta.set {
             self.update_texture(*id, image_delta);
@@ -679,62 +641,51 @@ impl Renderer {
                         eprintln!("This texture no longer exists {:?}", mesh.texture_id);
                         continue;
                     }
-
-                    // let scissors = [self.get_rect_scissor(
-                    //     scale_factor,
-                    //     framebuffer_dimensions,
-                    //     *clip_rect,
-                    // )].into_iter().collect();
-                    let mut scissors = SmallVec::new();
-                    scissors.push(self.get_rect_scissor(
-                        scale_factor,
-                        framebuffer_dimensions,
-                        *clip_rect,
-                    ));
-
                     let (vertices, indices) = self.create_subbuffers(mesh);
-
                     let desc_set = self.texture_desc_sets.get(&mesh.texture_id).unwrap();
-
-                    let mut viewport = SmallVec::new();
-                    viewport.push(Viewport {
-                        offset: [0.0, 0.0],
-                        extent: [
-                            framebuffer_dimensions[0] as f32,
-                            framebuffer_dimensions[1] as f32,
-                        ],
-                        depth_range: 0.0..=1.0,
-                    });
 
                     builder
                         .bind_pipeline_graphics(self.pipeline.clone())
-                        .unwrap();
-                        // .set_viewport(0, [Viewport {
-                        //     offset: [0.0, 0.0],
-                        //     extent: [
-                        //         framebuffer_dimensions[0] as f32,
-                        //         framebuffer_dimensions[1] as f32,
-                        //     ],
-                        //     depth_range: 0.0..=1.0,
-                        // }].into_iter().collect())
-                    builder.set_viewport(0, viewport)
-                        .unwrap();
-                    builder.set_scissor(0, scissors)
-                        .unwrap();
-                    builder.bind_descriptor_sets(
+                        .unwrap()
+                        .set_viewport(
+                            0,
+                            [Viewport {
+                                offset: [0.0, 0.0],
+                                extent: [
+                                    framebuffer_dimensions[0] as f32,
+                                    framebuffer_dimensions[1] as f32,
+                                ],
+                                depth_range: 0.0..=1.0,
+                            }]
+                            .into_iter()
+                            .collect(),
+                        )
+                        .unwrap()
+                        .set_scissor(
+                            0,
+                            [self.get_rect_scissor(
+                                scale_factor,
+                                framebuffer_dimensions,
+                                *clip_rect,
+                            )]
+                            .into_iter()
+                            .collect(),
+                        )
+                        .unwrap()
+                        .bind_descriptor_sets(
                             PipelineBindPoint::Graphics,
                             self.pipeline.layout().clone(),
                             0,
                             desc_set.clone(),
                         )
-                        .unwrap();
-                    builder.push_constants(self.pipeline.layout().clone(), 0, push_constants)
-                        .unwrap();
-                    builder.bind_vertex_buffers(0, vertices.clone())
-                        .unwrap();
-                    builder.bind_index_buffer(indices.clone())
-                        .unwrap();
-                    builder.draw_indexed(indices.len() as u32, 1, 0, 0, 0)
+                        .unwrap()
+                        .push_constants(self.pipeline.layout().clone(), 0, push_constants)
+                        .unwrap()
+                        .bind_vertex_buffers(0, vertices.clone())
+                        .unwrap()
+                        .bind_index_buffer(indices.clone())
+                        .unwrap()
+                        .draw_indexed(indices.len() as u32, 1, 0, 0, 0)
                         .unwrap();
                 }
                 Primitive::Callback(callback) => {
@@ -749,34 +700,28 @@ impl Renderer {
                         let rect_max_x = rect_max_x.round();
                         let rect_max_y = rect_max_y.round();
 
-                        // let scissors = [self.get_rect_scissor(
-                        //     scale_factor,
-                        //     framebuffer_dimensions,
-                        //     *clip_rect,
-                        // )].into_iter().collect();
-                        let mut scissors = SmallVec::new();
-                        scissors.push(self.get_rect_scissor(
-                            scale_factor,
-                            framebuffer_dimensions,
-                            *clip_rect,
-                        ));
-
-                        let mut viewport = SmallVec::new();
-                        viewport.push(Viewport {
-                            offset: [rect_min_x, rect_min_y],
-                            extent: [rect_max_x - rect_min_x, rect_max_y - rect_min_y],
-                            depth_range: 0.0..=1.0,
-                        });
-
                         builder
-                            // .set_viewport(0, [Viewport {
-                            //     offset: [rect_min_x, rect_min_y],
-                            //     extent: [rect_max_x - rect_min_x, rect_max_y - rect_min_y],
-                            //     depth_range: 0.0..=1.0,
-                            // }].into_iter().collect())
-                            .set_viewport(0, viewport)
+                            .set_viewport(
+                                0,
+                                [Viewport {
+                                    offset: [rect_min_x, rect_min_y],
+                                    extent: [rect_max_x - rect_min_x, rect_max_y - rect_min_y],
+                                    depth_range: 0.0..=1.0,
+                                }]
+                                .into_iter()
+                                .collect(),
+                            )
                             .unwrap()
-                            .set_scissor(0, scissors)
+                            .set_scissor(
+                                0,
+                                [self.get_rect_scissor(
+                                    scale_factor,
+                                    framebuffer_dimensions,
+                                    *clip_rect,
+                                )]
+                                .into_iter()
+                                .collect(),
+                            )
                             .unwrap();
 
                         let info = egui::PaintCallbackInfo {
@@ -787,10 +732,13 @@ impl Renderer {
                         };
 
                         if let Some(callback) = callback.callback.downcast_ref::<CallbackFn>() {
-                            (callback.f)(info, &mut CallbackContext {
-                                builder,
-                                resources: self.render_resources(),
-                            });
+                            (callback.f)(
+                                info,
+                                &mut CallbackContext {
+                                    builder,
+                                    resources: self.render_resources(),
+                                },
+                            );
                         } else {
                             println!(
                                 "Warning: Unsupported render callback. Expected \

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -299,7 +299,7 @@ impl Renderer {
         image: Arc<ImageView>,
         sampler_create_info: SamplerCreateInfo,
     ) -> egui::TextureId {
-        let layout = self.pipeline.layout().set_layouts().get(0).unwrap();
+        let layout = self.pipeline.layout().set_layouts().first().unwrap();
         let sampler = Sampler::new(self.gfx_queue.device().clone(), sampler_create_info).unwrap();
         let desc_set = self.sampled_image_desc_set(layout, image.clone(), sampler);
         let id = egui::TextureId::User(self.next_native_tex_id);
@@ -409,7 +409,7 @@ impl Renderer {
             }
             // Otherwise save the newly created image
         } else {
-            let layout = self.pipeline.layout().set_layouts().get(0).unwrap();
+            let layout = self.pipeline.layout().set_layouts().first().unwrap();
             let font_desc_set =
                 self.sampled_image_desc_set(layout, font_image.clone(), self.font_sampler.clone());
             self.texture_desc_sets.insert(texture_id, font_desc_set);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,20 +10,17 @@
 use std::sync::Arc;
 
 use image::RgbaImage;
-use vulkano::buffer::{AllocateBufferError, Buffer, BufferCreateInfo, BufferUsage};
-use vulkano::command_buffer::allocator::StandardCommandBufferAllocatorCreateInfo;
-use vulkano::command_buffer::CopyBufferToImageInfo;
-use vulkano::image::view::ImageView;
-use vulkano::image::{AllocateImageError, Image, ImageCreateInfo, ImageType, ImageUsage};
-use vulkano::memory::allocator::{AllocationCreateInfo, MemoryTypeFilter};
 use vulkano::{
+    buffer::{AllocateBufferError, Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
-        allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
+        allocator::{StandardCommandBufferAllocator, StandardCommandBufferAllocatorCreateInfo},
+        AutoCommandBufferBuilder, CommandBufferUsage, CopyBufferToImageInfo,
         PrimaryCommandBufferAbstract,
     },
     descriptor_set::allocator::StandardDescriptorSetAllocator,
     device::{Device, Queue},
-    memory::allocator::StandardMemoryAllocator,
+    image::{view::ImageView, AllocateImageError, Image, ImageCreateInfo, ImageType, ImageUsage},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     Validated, ValidationError, VulkanError,
 };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,16 +10,30 @@
 use std::sync::Arc;
 
 use image::RgbaImage;
-use vulkano::{command_buffer::{
-    allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-    PrimaryCommandBufferAbstract,
-}, descriptor_set::allocator::StandardDescriptorSetAllocator, device::{Device, Queue}, memory::allocator::StandardMemoryAllocator, Validated};
-use vulkano::buffer::{Buffer, BufferCreateInfo, BufferUsage};
+use vulkano::buffer::{AllocateBufferError, Buffer, BufferCreateInfo, BufferUsage};
 use vulkano::command_buffer::allocator::StandardCommandBufferAllocatorCreateInfo;
 use vulkano::command_buffer::CopyBufferToImageInfo;
-use vulkano::image::{AllocateImageError, Image, ImageCreateInfo, ImageType, ImageUsage};
 use vulkano::image::view::ImageView;
+use vulkano::image::{AllocateImageError, Image, ImageCreateInfo, ImageType, ImageUsage};
 use vulkano::memory::allocator::{AllocationCreateInfo, MemoryTypeFilter};
+use vulkano::{
+    command_buffer::{
+        allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
+        PrimaryCommandBufferAbstract,
+    },
+    descriptor_set::allocator::StandardDescriptorSetAllocator,
+    device::{Device, Queue},
+    memory::allocator::StandardMemoryAllocator,
+    Validated, ValidationError, VulkanError,
+};
+
+#[derive(Debug)]
+pub enum ImageCreationError {
+    VulkanError(Validated<VulkanError>),
+    AllocateImageError(Validated<AllocateImageError>),
+    AllocateBufferError(Validated<AllocateBufferError>),
+    ValidationError(Box<ValidationError>),
+}
 
 pub fn immutable_texture_from_bytes(
     allocators: &Allocators,
@@ -27,41 +41,25 @@ pub fn immutable_texture_from_bytes(
     byte_data: &[u8],
     dimensions: [u32; 2],
     format: vulkano::format::Format,
-// ) -> Result<Arc<dyn ImageViewAbstract + Send + Sync + 'static>, ImmutableImageCreationError> {
-) -> Result<Arc<ImageView>, Validated<AllocateImageError>> {
-    // let vko_dims =
-    //     ImageDimensions::Dim2d { width: dimensions[0], height: dimensions[1], array_layers: 1 };
-
+) -> Result<Arc<ImageView>, ImageCreationError> {
     let mut cbb = AutoCommandBufferBuilder::primary(
         &allocators.command_buffer,
         queue.queue_family_index(),
         CommandBufferUsage::OneTimeSubmit,
-    ).unwrap();
-    // TODO(aedm): unwrap
-
-    // let texture = ImmutableImage::from_iter(
-    //     &allocators.memory,
-    //     byte_data.iter().cloned(),
-    //     vko_dims,
-    //     MipmapsCount::One,
-    //     format,
-    //     &mut cbb,
-    // )?;
-
-    let data_copy = byte_data.to_vec();
+    )
+    .map_err(ImageCreationError::VulkanError)?;
 
     let texture_data_buffer = Buffer::from_iter(
         allocators.memory.clone(),
         BufferCreateInfo { usage: BufferUsage::TRANSFER_SRC, ..Default::default() },
-        // AllocationCreateInfo { usage: MemoryUsage::Upload, ..Default::default() },
         AllocationCreateInfo {
             memory_type_filter: MemoryTypeFilter::PREFER_HOST
                 | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
-        data_copy,
-    ).unwrap();
-    // TODO(aedm): unwrap
+        byte_data.iter().cloned(),
+    )
+    .map_err(ImageCreationError::AllocateBufferError)?;
 
     let texture = Image::new(
         allocators.memory.clone(),
@@ -73,16 +71,14 @@ pub fn immutable_texture_from_bytes(
             ..Default::default()
         },
         AllocationCreateInfo::default(),
-    )?;
+    )
+    .map_err(ImageCreationError::AllocateImageError)?;
 
-    cbb
-        .copy_buffer_to_image(CopyBufferToImageInfo::buffer_image(
-            texture_data_buffer,
-            texture.clone(),
-        ))
-        .unwrap();
-    // TODO(aedm): unwrap
-
+    cbb.copy_buffer_to_image(CopyBufferToImageInfo::buffer_image(
+        texture_data_buffer,
+        texture.clone(),
+    ))
+    .map_err(ImageCreationError::ValidationError)?;
 
     let _fut = cbb.build().unwrap().execute(queue).unwrap();
 
@@ -94,8 +90,7 @@ pub fn immutable_texture_from_file(
     queue: Arc<Queue>,
     file_bytes: &[u8],
     format: vulkano::format::Format,
-// ) -> Result<Arc<dyn ImageViewAbstract + Send + Sync + 'static>, ImmutableImageCreationError> {
-    ) -> Result<Arc<ImageView>, Validated<AllocateImageError>> {
+) -> Result<Arc<ImageView>, ImageCreationError> {
     use image::GenericImageView;
 
     let img = image::load_from_memory(file_bytes).expect("Failed to load image from bytes");
@@ -129,10 +124,13 @@ impl Allocators {
         Self {
             memory: Arc::new(StandardMemoryAllocator::new_default(device.clone())),
             descriptor_set: StandardDescriptorSetAllocator::new(device.clone(), Default::default()),
-            command_buffer: StandardCommandBufferAllocator::new(device.clone(), StandardCommandBufferAllocatorCreateInfo {
-                secondary_buffer_count: 32,
-                ..Default::default()
-            }),
+            command_buffer: StandardCommandBufferAllocator::new(
+                device.clone(),
+                StandardCommandBufferAllocatorCreateInfo {
+                    secondary_buffer_count: 32,
+                    ..Default::default()
+                },
+            ),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,10 +26,10 @@ use vulkano::{
 
 #[derive(Debug)]
 pub enum ImageCreationError {
-    VulkanError(Validated<VulkanError>),
-    AllocateImageError(Validated<AllocateImageError>),
-    AllocateBufferError(Validated<AllocateBufferError>),
-    ValidationError(Box<ValidationError>),
+    Vulkan(Validated<VulkanError>),
+    AllocateImage(Validated<AllocateImageError>),
+    AllocateBuffer(Validated<AllocateBufferError>),
+    Validation(Box<ValidationError>),
 }
 
 pub fn immutable_texture_from_bytes(
@@ -44,7 +44,7 @@ pub fn immutable_texture_from_bytes(
         queue.queue_family_index(),
         CommandBufferUsage::OneTimeSubmit,
     )
-    .map_err(ImageCreationError::VulkanError)?;
+    .map_err(ImageCreationError::Vulkan)?;
 
     let texture_data_buffer = Buffer::from_iter(
         allocators.memory.clone(),
@@ -56,7 +56,7 @@ pub fn immutable_texture_from_bytes(
         },
         byte_data.iter().cloned(),
     )
-    .map_err(ImageCreationError::AllocateBufferError)?;
+    .map_err(ImageCreationError::AllocateBuffer)?;
 
     let texture = Image::new(
         allocators.memory.clone(),
@@ -69,13 +69,13 @@ pub fn immutable_texture_from_bytes(
         },
         AllocationCreateInfo::default(),
     )
-    .map_err(ImageCreationError::AllocateImageError)?;
+    .map_err(ImageCreationError::AllocateImage)?;
 
     cbb.copy_buffer_to_image(CopyBufferToImageInfo::buffer_image(
         texture_data_buffer,
         texture.clone(),
     ))
-    .map_err(ImageCreationError::ValidationError)?;
+    .map_err(ImageCreationError::Validation)?;
 
     let _fut = cbb.build().unwrap().execute(queue).unwrap();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,19 +10,16 @@
 use std::sync::Arc;
 
 use image::RgbaImage;
-use vulkano::{
-    command_buffer::{
-        allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        PrimaryCommandBufferAbstract,
-    },
-    descriptor_set::allocator::StandardDescriptorSetAllocator,
-    device::{Device, Queue},
-    image::{
-        immutable::ImmutableImageCreationError, view::ImageView, ImageDimensions,
-        ImageViewAbstract, ImmutableImage, MipmapsCount,
-    },
-    memory::allocator::StandardMemoryAllocator,
-};
+use vulkano::{command_buffer::{
+    allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
+    PrimaryCommandBufferAbstract,
+}, descriptor_set::allocator::StandardDescriptorSetAllocator, device::{Device, Queue}, memory::allocator::StandardMemoryAllocator, Validated};
+use vulkano::buffer::{Buffer, BufferCreateInfo, BufferUsage};
+use vulkano::command_buffer::allocator::StandardCommandBufferAllocatorCreateInfo;
+use vulkano::command_buffer::CopyBufferToImageInfo;
+use vulkano::image::{AllocateImageError, Image, ImageCreateInfo, ImageType, ImageUsage};
+use vulkano::image::view::ImageView;
+use vulkano::memory::allocator::{AllocationCreateInfo, MemoryTypeFilter};
 
 pub fn immutable_texture_from_bytes(
     allocators: &Allocators,
@@ -30,23 +27,63 @@ pub fn immutable_texture_from_bytes(
     byte_data: &[u8],
     dimensions: [u32; 2],
     format: vulkano::format::Format,
-) -> Result<Arc<dyn ImageViewAbstract + Send + Sync + 'static>, ImmutableImageCreationError> {
-    let vko_dims =
-        ImageDimensions::Dim2d { width: dimensions[0], height: dimensions[1], array_layers: 1 };
+// ) -> Result<Arc<dyn ImageViewAbstract + Send + Sync + 'static>, ImmutableImageCreationError> {
+) -> Result<Arc<ImageView>, Validated<AllocateImageError>> {
+    // let vko_dims =
+    //     ImageDimensions::Dim2d { width: dimensions[0], height: dimensions[1], array_layers: 1 };
 
     let mut cbb = AutoCommandBufferBuilder::primary(
         &allocators.command_buffer,
         queue.queue_family_index(),
         CommandBufferUsage::OneTimeSubmit,
+    ).unwrap();
+    // TODO(aedm): unwrap
+
+    // let texture = ImmutableImage::from_iter(
+    //     &allocators.memory,
+    //     byte_data.iter().cloned(),
+    //     vko_dims,
+    //     MipmapsCount::One,
+    //     format,
+    //     &mut cbb,
+    // )?;
+
+    let data_copy = byte_data.to_vec();
+
+    let texture_data_buffer = Buffer::from_iter(
+        allocators.memory.clone(),
+        BufferCreateInfo { usage: BufferUsage::TRANSFER_SRC, ..Default::default() },
+        // AllocationCreateInfo { usage: MemoryUsage::Upload, ..Default::default() },
+        AllocationCreateInfo {
+            memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
+            ..Default::default()
+        },
+        data_copy,
+    ).unwrap();
+    // TODO(aedm): unwrap
+
+    let texture = Image::new(
+        allocators.memory.clone(),
+        ImageCreateInfo {
+            image_type: ImageType::Dim2d,
+            format,
+            extent: [dimensions[0], dimensions[1], 1],
+            usage: ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED,
+            ..Default::default()
+        },
+        AllocationCreateInfo::default(),
     )?;
-    let texture = ImmutableImage::from_iter(
-        &allocators.memory,
-        byte_data.iter().cloned(),
-        vko_dims,
-        MipmapsCount::One,
-        format,
-        &mut cbb,
-    )?;
+
+    cbb
+        .copy_buffer_to_image(CopyBufferToImageInfo::buffer_image(
+            texture_data_buffer,
+            texture.clone(),
+        ))
+        .unwrap();
+    // TODO(aedm): unwrap
+
+
     let _fut = cbb.build().unwrap().execute(queue).unwrap();
 
     Ok(ImageView::new_default(texture).unwrap())
@@ -57,7 +94,8 @@ pub fn immutable_texture_from_file(
     queue: Arc<Queue>,
     file_bytes: &[u8],
     format: vulkano::format::Format,
-) -> Result<Arc<dyn ImageViewAbstract + Send + Sync + 'static>, ImmutableImageCreationError> {
+// ) -> Result<Arc<dyn ImageViewAbstract + Send + Sync + 'static>, ImmutableImageCreationError> {
+    ) -> Result<Arc<ImageView>, Validated<AllocateImageError>> {
     use image::GenericImageView;
 
     let img = image::load_from_memory(file_bytes).expect("Failed to load image from bytes");
@@ -90,8 +128,11 @@ impl Allocators {
     pub fn new_default(device: &Arc<Device>) -> Self {
         Self {
             memory: Arc::new(StandardMemoryAllocator::new_default(device.clone())),
-            descriptor_set: StandardDescriptorSetAllocator::new(device.clone()),
-            command_buffer: StandardCommandBufferAllocator::new(device.clone(), Default::default()),
+            descriptor_set: StandardDescriptorSetAllocator::new(device.clone(), Default::default()),
+            command_buffer: StandardCommandBufferAllocator::new(device.clone(), StandardCommandBufferAllocatorCreateInfo {
+                secondary_buffer_count: 32,
+                ..Default::default()
+            }),
         }
     }
 }


### PR DESCRIPTION
Updates the Vulkano depencency to `0.34`.

It also changes the Rust edition from `2018` to `2021`. The reason for that is that Vulkano 0.34 requires some data collections to be passed as SmallVec. The syntax `[...].into_iter().collect()` only works in Rust 2021 without importing SmallVec.