### PR TITLE
Dynamic font format to minimize mem/work

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -324,7 +324,6 @@ impl Renderer {
     /// Choose a font format, attempt to minimize memory footprint and CPU unpacking time
     /// by choosing a swizzled linear format.
     fn choose_font_format(device: &vulkano::device::Device) -> Format {
-        return Format::R8G8B8A8_SRGB;
         // Some portability subset devices are unable to swizzle views.
         let supports_swizzle =
             !device.physical_device().supported_extensions().khr_portability_subset
@@ -345,10 +344,11 @@ impl Renderer {
         };
         if supports_swizzle && is_supported(device, Format::R8G8_UNORM) {
             // We can save mem by swizzling in hardware!
-            return Format::R8G8_UNORM;
+            Format::R8G8_UNORM
+        } else {
+            // Rest of implementation assumes R8G8B8A8_SRGB anyway!
+            Format::R8G8B8A8_SRGB
         }
-        // Rest of implementation assumes R8G8B8A8_SRGB anyway!
-        Format::R8G8B8A8_SRGB
     }
 
     /// Based on self.font_format, extract into bytes.


### PR DESCRIPTION
Egui Font textures are single-channel images representing linear coverage of white. This PR takes advantage of this to reduce texture and staging memory usage by 4x on supporting devices (~90% coverage according to gpuinfo.org) while providing fallbacks for non-supporting devices and portability subset devices, as well as reducing the work required to upload these images (elides a sqrt per pixel on the host side).

Comparing all four possible image formats implemented here, which prioritize memory footprint and then prioritize work reduction, the visual differences are subtle. This is because egui's `font_image.srgba_pixels(None)` is an [approximation of Linear->sRGB](https://github.com/emilk/egui/blob/301c72ba22da8f29596d65757cf3dacdf5309985/crates/epaint/src/image.rs#L293) so the new implementation is likely strictly more correct by skipping this and using the linear coverage directly. Notably, `R8_SRGB`/`R8G8B8A8_SRG` are in perfect parity with each other and current master, and `R8_UNORM`/`R8G8B8A8_UNORM` are in perfect parity with each other providing a slightly higher contrast which I believe is a more correct result.

I have more work I would like to contribute to the image uploading process which could reduce temporary host memory allocation by an extra ~2x and elide a number of copies, if that would be appreciated! ^^ To avoid conflicts though, I would like to receive feedback on this before setting off on that journey.