### PR TITLE
Batched/Linear uploads

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -73,6 +73,9 @@ const VERTICES_PER_QUAD: DeviceSize = 4;
 const VERTEX_BUFFER_SIZE: DeviceSize = 1024 * 1024 * VERTICES_PER_QUAD;
 const INDEX_BUFFER_SIZE: DeviceSize = 1024 * 1024 * 2;
 
+type VertexBuffer = Subbuffer<[egui::epaint::Vertex]>;
+type IndexBuffer = Subbuffer<[u32]>;
+
 /// Should match vertex definition of egui
 #[repr(C)]
 #[derive(BufferContents, Vertex)]
@@ -599,7 +602,7 @@ impl Renderer {
     fn upload_meshes(
         &mut self,
         clipped_meshes: &[ClippedPrimitive],
-    ) -> Option<(Subbuffer<[egui::epaint::Vertex]>, Subbuffer<[u32]>)> {
+    ) -> Option<(VertexBuffer, IndexBuffer)> {
         use egui::epaint::Vertex;
         type Index = u32;
         const VERTEX_ALIGN: DeviceAlignment = DeviceAlignment::of::<Vertex>();

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -13,10 +13,7 @@ use std::{
 };
 
 use ahash::AHashMap;
-use egui::{
-    epaint::{Mesh, Primitive},
-    ClippedPrimitive, PaintCallbackInfo, Rect, TexturesDelta,
-};
+use egui::{epaint::Primitive, ClippedPrimitive, PaintCallbackInfo, Rect, TexturesDelta};
 use vulkano::{
     buffer::{
         allocator::{SubbufferAllocator, SubbufferAllocatorCreateInfo},
@@ -47,7 +44,7 @@ use vulkano::{
         allocator::{
             AllocationCreateInfo, DeviceLayout, MemoryTypeFilter, StandardMemoryAllocator,
         },
-        DeviceAlignment, MemoryPropertyFlags,
+        DeviceAlignment,
     },
     pipeline::{
         graphics::{


### PR DESCRIPTION
Replaces the allocate-as-needed logic with bulk linear allocations for both image create, image update, and mesh upload.

* ~~Doubles the framerate over master~~ when compared using a modified `demo_app.rs` with `PresentMode::Mailbox` and a few spare swapchain images, even using 1% *less* of my CPU while doing so. It also starts up a sixteenth of a second faster, clearly the largest benefit here :P

* Image uploads are now batched per-frame and only synchronize once. Should help with stutter on UIs that load/modify fonts or images frequently (Scrubbing the font size slider on the `demo_app`'s FontBook is a good example).
  * Could further improve this by not synchronizing the host at all, leaving all sync to the device.

* Mesh uploads now only memmap the buffers twice-per-frame instead of twice-per-mesh.
  * With a dependency on `bytemuck` this could be further reduced to a single memmap per frame, but it would require a private dependency addition and a public egui feature flag change for a somewhat trivial perf boost, and I'm not sure the policy on that (could also be achieved with some fairly trivial `unsafe` ops).

* It should use substantially less memory during these operations, but I do not have a convenient way to measure. On current master, image creation/deltas involve 4 in-memory copies, reduced here to 2.

I have further optimizations in mind, namely deduplicating command buffer commands, as there are currently ~250 commands for 20 meshes which could be greatly reduced. _Always unsure on whether I should bundle the changes into one PR since they're a bit disjoint -- please advise!_
