### PR TITLE
Mark image and dependencies of winit as optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,18 @@ categories = ["gui", "game-development"]
 keywords = ["gui", "imgui", "immediate", "portable", "gamedev"]
 
 [features]
-default = ["clipboard", "links"]
+default = ["clipboard", "links", "wayland", "x11"]
 links = ["egui-winit/links"]
 clipboard = ["egui-winit/clipboard"]
+wayland = ["winit/wayland", "winit/wayland-dlopen", "egui-winit/wayland"]
+x11 = ["winit/x11", "egui-winit/x11"]
 
 [dependencies]
 ahash = "0.8.3"
-egui-winit = "0.24"
+egui-winit = { version = "0.24", default-features = false }
 egui = "0.24"
-image = "0.24.5"
-winit = "0.28.2"
+image = { version = "0.24.5", optional = true }
+winit = { version = "0.28", default-features = false }
 vulkano = "0.34"
 vulkano-shaders = "0.34"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["gui", "game-development"]
 keywords = ["gui", "imgui", "immediate", "portable", "gamedev"]
 
 [features]
-default = ["clipboard", "links", "wayland", "x11"]
+default = ["clipboard", "links", "wayland", "x11", "image"]
 links = ["egui-winit/links"]
 clipboard = ["egui-winit/clipboard"]
 wayland = ["winit/wayland", "winit/wayland-dlopen", "egui-winit/wayland"]

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -23,8 +23,10 @@ use winit::window::Window;
 
 use crate::{
     renderer::{RenderResources, Renderer},
-    utils::{immutable_texture_from_bytes, immutable_texture_from_file},
+    utils::immutable_texture_from_bytes,
 };
+#[cfg(feature = "image")]
+use crate::utils::immutable_texture_from_file;
 
 pub struct GuiConfig {
     /// Allows supplying sRGB ImageViews as render targets instead of just UNORM ImageViews, defaults to false.
@@ -267,6 +269,7 @@ impl Gui {
     /// Registers a user image to be used by egui
     /// - `image_file_bytes`: e.g. include_bytes!("./assets/tree.png")
     /// - `format`: e.g. vulkano::format::Format::R8G8B8A8Unorm
+    #[cfg(feature = "image")]
     pub fn register_user_image(
         &mut self,
         image_file_bytes: &[u8],

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -21,12 +21,12 @@ use vulkano::{
 };
 use winit::window::Window;
 
+#[cfg(feature = "image")]
+use crate::utils::immutable_texture_from_file;
 use crate::{
     renderer::{RenderResources, Renderer},
     utils::immutable_texture_from_bytes,
 };
-#[cfg(feature = "image")]
-use crate::utils::immutable_texture_from_file;
 
 pub struct GuiConfig {
     /// Allows supplying sRGB ImageViews as render targets instead of just UNORM ImageViews, defaults to false.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,6 @@ mod utils;
 pub use egui;
 pub use integration::*;
 pub use renderer::{CallbackContext, CallbackFn, RenderResources};
-pub use utils::{immutable_texture_from_bytes, immutable_texture_from_file};
+pub use utils::immutable_texture_from_bytes;
+#[cfg(feature = "image")]
+pub use utils::immutable_texture_from_file;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,6 +9,7 @@
 
 use std::sync::Arc;
 
+#[cfg(feature = "image")]
 use image::RgbaImage;
 use vulkano::{
     buffer::{AllocateBufferError, Buffer, BufferCreateInfo, BufferUsage},
@@ -82,6 +83,7 @@ pub fn immutable_texture_from_bytes(
     Ok(ImageView::new_default(texture).unwrap())
 }
 
+#[cfg(feature = "image")]
 pub fn immutable_texture_from_file(
     allocators: &Allocators,
     queue: Arc<Queue>,


### PR DESCRIPTION
This allows people who do not wish to use these crates to not pull them.