### PR TITLE
Enable image_view_format_swizzle feature

### DIFF
--- a/examples/demo_app.rs
+++ b/examples/demo_app.rs
@@ -38,7 +38,9 @@ pub struct Window {
 impl Default for App {
     fn default() -> Self {
         // Vulkano context
-        let context = VulkanoContext::new(VulkanoConfig::default());
+        let mut config = VulkanoConfig::default();
+        config.device_features.image_view_format_swizzle = true;
+        let context = VulkanoContext::new(config);
         // Vulkano windows (create one)
         let windows = VulkanoWindows::default();
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -34,7 +34,9 @@ pub struct App {
 impl Default for App {
     fn default() -> Self {
         // Vulkano context
-        let context = VulkanoContext::new(VulkanoConfig::default());
+        let mut config = VulkanoConfig::default();
+        config.device_features.image_view_format_swizzle = true;
+        let context = VulkanoContext::new(config);
 
         // Vulkano windows
         let windows = VulkanoWindows::default();

--- a/examples/multisample.rs
+++ b/examples/multisample.rs
@@ -59,7 +59,9 @@ pub struct App {
 impl Default for App {
     fn default() -> Self {
         // Vulkano context
-        let context = VulkanoContext::new(VulkanoConfig::default());
+        let mut config = VulkanoConfig::default();
+        config.device_features.image_view_format_swizzle = true;
+        let context = VulkanoContext::new(config);
 
         // Vulkano windows
         let windows = VulkanoWindows::default();

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -44,7 +44,9 @@ pub struct App {
 impl Default for App {
     fn default() -> Self {
         // Vulkano context
-        let context = VulkanoContext::new(VulkanoConfig::default());
+        let mut config = VulkanoConfig::default();
+        config.device_features.image_view_format_swizzle = true;
+        let context = VulkanoContext::new(config);
 
         // Vulkano windows
         let windows = VulkanoWindows::default();

--- a/examples/subpass.rs
+++ b/examples/subpass.rs
@@ -60,7 +60,9 @@ pub struct App {
 impl Default for App {
     fn default() -> Self {
         // Vulkano context
-        let context = VulkanoContext::new(VulkanoConfig::default());
+        let mut config = VulkanoConfig::default();
+        config.device_features.image_view_format_swizzle = true;
+        let context = VulkanoContext::new(config);
 
         // Vulkano windows
         let windows = VulkanoWindows::default();

--- a/examples/wholesome/main.rs
+++ b/examples/wholesome/main.rs
@@ -141,7 +141,9 @@ pub struct App {
 impl Default for App {
     fn default() -> Self {
         // Vulkano context
-        let context = VulkanoContext::new(VulkanoConfig::default());
+        let mut config = VulkanoConfig::default();
+        config.device_features.image_view_format_swizzle = true;
+        let context = VulkanoContext::new(config);
 
         // Vulkano windows
         let windows = VulkanoWindows::default();

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -308,8 +308,8 @@ impl Renderer {
     fn choose_font_format(device: &vulkano::device::Device) -> Format {
         // Some portability subset devices are unable to swizzle views.
         let supports_swizzle =
-            !device.physical_device().supported_extensions().khr_portability_subset
-                || device.physical_device().supported_features().image_view_format_swizzle;
+            !device.enabled_extensions().khr_portability_subset
+                || device.enabled_features().image_view_format_swizzle;
         // Check that this format is supported for all our uses:
         let is_supported = |device: &vulkano::device::Device, format: Format| {
             device


### PR DESCRIPTION
Fixes https://github.com/hakolao/egui_winit_vulkano/issues/71

Need to enable it before it can be used (at least on macOS). Also switching to check for enabled instead of supported.